### PR TITLE
Refactor services to support cancellation tokens and enhance health checks; update options and configurations

### DIFF
--- a/.idea/copilot.data.migration.agent.xml
+++ b/.idea/copilot.data.migration.agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/copilot.data.migration.ask.xml
+++ b/.idea/copilot.data.migration.ask.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AskMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/copilot.data.migration.ask2agent.xml
+++ b/.idea/copilot.data.migration.ask2agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Ask2AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/copilot.data.migration.edit.xml
+++ b/.idea/copilot.data.migration.edit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EditMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/DEPLOYMENT_STRATEGIES.md
+++ b/DEPLOYMENT_STRATEGIES.md
@@ -1,0 +1,596 @@
+# Advanced Deployment Strategies Guide
+
+This guide covers the advanced deployment strategies implemented for the E2E Data Pipeline, including Blue/Green deployments, Canary deployments, and progressive delivery patterns.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Architecture](#architecture)
+3. [Prerequisites](#prerequisites)
+4. [Installation](#installation)
+5. [Deployment Strategies](#deployment-strategies)
+6. [Monitoring & Observability](#monitoring--observability)
+7. [Troubleshooting](#troubleshooting)
+8. [Best Practices](#best-practices)
+
+---
+
+## Overview
+
+### What's New
+
+This project now includes enterprise-grade deployment capabilities:
+
+- **Blue/Green Deployments**: Zero-downtime deployments with instant rollback capability
+- **Canary Deployments**: Progressive traffic shifting with automated analysis
+- **Automated Analysis**: Prometheus-based metrics analysis during deployments
+- **Traffic Management**: Advanced routing with AWS ALB and Nginx Ingress
+- **Monitoring**: Real-time deployment metrics and dashboards
+- **GitOps Integration**: Argo CD with Argo Rollouts for continuous delivery
+
+### Key Benefits
+
+- **Zero Downtime**: All deployment strategies ensure no service interruption
+- **Risk Mitigation**: Progressive rollouts and automated rollbacks reduce deployment risk
+- **Automated Quality Gates**: Analysis templates validate deployments before promotion
+- **Visibility**: Comprehensive monitoring and alerting for deployment health
+- **Speed**: Faster rollbacks and controlled traffic shifting
+
+---
+
+## Architecture
+
+### Components
+
+```mermaid
+graph TB
+    subgraph TM["Traffic Management"]
+        ALB[AWS ALB]
+        NI[Nginx Ingress]
+        SM[Service Mesh]
+    end
+    
+    subgraph DE["Deployment Engine"]
+        subgraph AR["Argo Rollouts"]
+            BG[Blue/Green Strategy]
+            CS[Canary Strategy]
+        end
+    end
+    
+    subgraph AM["Analysis & Metrics"]
+        PROM[Prometheus]
+        GRAF[Grafana]
+        ALERT[AlertManager]
+    end
+    
+    TM --> DE
+    DE --> AM
+```
+
+### Deployment Flow
+
+#### Blue/Green Deployment
+
+```mermaid
+graph LR
+    A[1. Deploy Green<br/>Preview] --> B[2. Run Tests &<br/>Analysis]
+    B --> C[3. Manual/Auto<br/>Verification]
+    C --> D[4. Switch Traffic<br/>Blue → Green]
+    D --> E[5. Keep Blue for<br/>Instant Rollback]
+    E --> F[6. Decommission<br/>Blue]
+```
+
+#### Canary Deployment
+
+```mermaid
+graph TD
+    A[1. Deploy Canary] --> B[2. Route 10%<br/>Traffic to Canary]
+    B --> C{3. Analysis Pass?}
+    C -->|Yes| D[4. Increase to 25%]
+    C -->|No| Z[Auto-Rollback]
+    D --> E{Analysis Pass?}
+    E -->|Yes| F[5. Increase to 50%]
+    E -->|No| Z
+    F --> G{Analysis Pass?}
+    G -->|Yes| H[6. Increase to 75%]
+    G -->|No| Z
+    H --> I{Analysis Pass?}
+    I -->|Yes| J[7. Promote to 100%]
+    I -->|No| Z
+```
+
+---
+
+## Prerequisites
+
+### Required Tools
+
+- **kubectl** (v1.24+)
+- **helm** (v3.10+)
+- **AWS CLI** (v2.0+) - for AWS deployments
+- **eksctl** (optional) - for EKS management
+- **jq** (optional) - for JSON parsing
+
+### Kubernetes Cluster
+
+- **Kubernetes**: v1.24+
+- **Minimum Nodes**: 3
+- **Node Size**: t3.medium or larger
+- **Storage**: Support for dynamic PVC provisioning
+
+### AWS Resources (for AWS deployments)
+
+- EKS Cluster
+- VPC with public/private subnets
+- IAM roles for service accounts
+- ACM certificate (for HTTPS)
+
+---
+
+## Installation
+
+### Quick Start
+
+```bash
+# 1. Navigate to scripts directory
+cd scripts
+
+# 2. Make scripts executable
+chmod +x *.sh
+
+# 3. Run setup script
+./setup-advanced-deployments.sh
+
+# 4. Verify installation
+kubectl get pods -n argo-rollouts
+kubectl get pods -n monitoring
+```
+
+### Manual Installation
+
+#### 1. Install Argo Rollouts
+
+```bash
+kubectl create namespace argo-rollouts
+kubectl apply -n argo-rollouts -f \
+  https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
+
+# Install kubectl plugin
+curl -LO https://github.com/argoproj/argo-rollouts/releases/latest/download/kubectl-argo-rollouts-linux-amd64
+chmod +x kubectl-argo-rollouts-linux-amd64
+sudo mv kubectl-argo-rollouts-linux-amd64 /usr/local/bin/kubectl-argo-rollouts
+```
+
+#### 2. Install Prometheus & Grafana
+
+```bash
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+
+helm install kube-prometheus prometheus-community/kube-prometheus-stack \
+  --namespace monitoring \
+  --create-namespace \
+  --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false
+```
+
+#### 3. Install Nginx Ingress (Optional)
+
+```bash
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm install ingress-nginx ingress-nginx/ingress-nginx \
+  --namespace ingress-nginx \
+  --create-namespace
+```
+
+#### 4. Apply Kubernetes Manifests
+
+```bash
+cd kubernetes
+
+# Apply services
+kubectl apply -f services.yaml
+
+# Apply analysis templates
+kubectl apply -f analysis-templates.yaml
+
+# Apply ServiceMonitors
+kubectl apply -f servicemonitors.yaml
+
+# Apply Ingress
+kubectl apply -f ingress.yaml
+```
+
+---
+
+## Deployment Strategies
+
+### Blue/Green Deployment
+
+#### Deploy with Script
+
+```bash
+cd scripts
+./deploy-blue-green.sh airflow v1.0.0
+```
+
+#### Manual Deployment
+
+```bash
+# Apply rollout manifest
+kubectl apply -f kubernetes/rollout-blue-green.yaml
+
+# Update image
+kubectl argo rollouts set image airflow-rollout \
+  airflow-webserver=myrepo/airflow-pipeline:v1.0.0
+
+# Check status
+kubectl argo rollouts get rollout airflow-rollout --watch
+
+# Promote to production
+kubectl argo rollouts promote airflow-rollout
+
+# Rollback if needed
+kubectl argo rollouts abort airflow-rollout
+kubectl argo rollouts undo airflow-rollout
+```
+
+#### Access Preview Environment
+
+```bash
+# Port-forward to preview service
+kubectl port-forward svc/airflow-webserver-preview 8081:8080
+
+# Test preview
+curl http://localhost:8081/health
+```
+
+### Canary Deployment
+
+#### Deploy with Script
+
+```bash
+cd scripts
+./deploy-canary.sh airflow v1.0.0
+```
+
+#### Manual Deployment
+
+```bash
+# Apply rollout manifest
+kubectl apply -f kubernetes/rollout-canary.yaml
+
+# Update image (triggers canary)
+kubectl argo rollouts set image airflow-canary-rollout \
+  airflow-webserver=myrepo/airflow-pipeline:v1.0.0
+
+# Monitor progress
+kubectl argo rollouts get rollout airflow-canary-rollout --watch
+
+# Manual promotion (if not using auto-promotion)
+kubectl argo rollouts promote airflow-canary-rollout
+
+# Abort and rollback
+kubectl argo rollouts abort airflow-canary-rollout
+```
+
+#### Canary Traffic Weights
+
+The default canary strategy uses progressive traffic shifting:
+- **Step 1**: 10% for 2 minutes
+- **Step 2**: 25% for 3 minutes
+- **Step 3**: 50% for 5 minutes
+- **Step 4**: 75% for 3 minutes
+- **Step 5**: 100% (full promotion)
+
+Each step includes automated analysis. Deployment auto-aborts on analysis failure.
+
+### Header-Based Canary (A/B Testing)
+
+```bash
+# Apply header-based canary
+kubectl apply -f kubernetes/rollout-canary.yaml
+
+# Access canary version with header
+curl -H "X-Version: canary" http://your-domain.com
+
+# Regular traffic goes to stable version
+curl http://your-domain.com
+```
+
+---
+
+## Monitoring & Observability
+
+### Access Dashboards
+
+#### Argo Rollouts Dashboard
+
+```bash
+kubectl port-forward -n argo-rollouts svc/argo-rollouts-dashboard 3100:3100
+# Open: http://localhost:3100
+```
+
+#### Grafana
+
+```bash
+kubectl port-forward -n monitoring svc/kube-prometheus-grafana 3000:80
+# Open: http://localhost:3000
+# Username: admin
+# Password: admin
+```
+
+#### Prometheus
+
+```bash
+kubectl port-forward -n monitoring svc/kube-prometheus-prometheus 9090:9090
+# Open: http://localhost:9090
+```
+
+### Import Grafana Dashboard
+
+```bash
+# The dashboard is located at: monitoring/grafana-deployment-dashboards.json
+
+# Import via UI:
+# 1. Login to Grafana
+# 2. Click "+" → Import
+# 3. Upload the JSON file
+# 4. Select Prometheus data source
+# 5. Click Import
+```
+
+### Key Metrics
+
+#### Success Rate
+```promql
+sum(rate(http_requests_total{status=~"2.."}[5m])) /
+sum(rate(http_requests_total[5m]))
+```
+
+#### Error Rate
+```promql
+sum(rate(http_requests_total{status=~"5.."}[5m])) /
+sum(rate(http_requests_total[5m]))
+```
+
+#### P95 Latency
+```promql
+histogram_quantile(0.95,
+  sum(rate(http_request_duration_milliseconds_bucket[5m])) by (le)
+)
+```
+
+### Alerts
+
+Alerts are automatically configured for:
+
+- High error rate (>5%)
+- High latency (P95 >1000ms)
+- Rollout degraded
+- Analysis run failed
+- Airflow task failures
+- Kafka consumer lag
+- Spark job failures
+
+Configure Slack notifications in `kubernetes/argo-rollouts-install.yaml`.
+
+---
+
+## Troubleshooting
+
+### Rollout Stuck in Progressing
+
+```bash
+# Check rollout status
+kubectl argo rollouts get rollout <rollout-name>
+
+# Check analysis runs
+kubectl get analysisruns
+
+# View analysis details
+kubectl describe analysisrun <analysis-run-name>
+
+# Check pod status
+kubectl get pods -l app=pipeline
+
+# View pod logs
+kubectl logs <pod-name>
+```
+
+### Analysis Failing
+
+```bash
+# Check Prometheus connectivity
+kubectl exec -it <rollout-pod> -- curl http://prometheus:9090/-/healthy
+
+# Verify metrics exist
+kubectl port-forward svc/prometheus 9090:9090
+# Open Prometheus UI and run query
+
+# Check ServiceMonitors
+kubectl get servicemonitors
+
+# View analysis template
+kubectl get analysistemplate <template-name> -o yaml
+```
+
+### Canary Not Receiving Traffic
+
+```bash
+# Check services
+kubectl get svc
+
+# Check ingress
+kubectl get ingress
+kubectl describe ingress <ingress-name>
+
+# Verify canary service selector
+kubectl get svc <canary-service> -o yaml
+
+# Check pod labels
+kubectl get pods --show-labels
+```
+
+### Rollback
+
+```bash
+# Abort current rollout
+kubectl argo rollouts abort <rollout-name>
+
+# Undo to previous version
+kubectl argo rollouts undo <rollout-name>
+
+# Undo to specific revision
+kubectl argo rollouts undo <rollout-name> --to-revision=2
+```
+
+---
+
+## Best Practices
+
+### Deployment Strategy Selection
+
+| Scenario | Recommended Strategy |
+|----------|---------------------|
+| Critical production service | Blue/Green |
+| High-traffic service | Canary |
+| Testing new features | Canary with header routing |
+| Database migrations | Blue/Green |
+| Quick iterations | Canary |
+| Stateful applications | Blue/Green |
+
+### Analysis Configuration
+
+1. **Set appropriate thresholds**: Don't make them too strict or too loose
+2. **Use multiple metrics**: Success rate + latency + errors
+3. **Set failure limits**: Allow 2-3 failures before aborting
+4. **Adjust intervals**: 30s for high-traffic, 60s for low-traffic
+
+### Traffic Management
+
+1. **Start with small percentages**: 10% for initial canary
+2. **Increase gradually**: 10% → 25% → 50% → 75% → 100%
+3. **Allow soak time**: Minimum 2-5 minutes per step
+4. **Monitor continuously**: Watch metrics during traffic shifts
+
+### Rollback Strategy
+
+1. **Set auto-rollback**: Configure analysis to auto-abort on failures
+2. **Keep blue/green environments**: Maintain for quick rollback
+3. **Test rollback procedures**: Practice rollbacks regularly
+4. **Document rollback playbooks**: Clear steps for emergencies
+
+### Security
+
+1. **Use RBAC**: Limit who can promote deployments
+2. **Require approvals**: Manual gates for production
+3. **Audit trails**: Track all deployment actions
+4. **Network policies**: Isolate preview environments
+
+---
+
+## Advanced Features
+
+### Progressive Experiments
+
+Test multiple versions simultaneously:
+
+```yaml
+experiments:
+  - name: version-comparison
+    templates:
+      - name: v1
+        specRef: stable
+        replicas: 2
+      - name: v2
+        specRef: canary
+        replicas: 2
+    duration: 10m
+```
+
+### Custom Analysis Providers
+
+Beyond Prometheus, support for:
+- Datadog
+- New Relic
+- CloudWatch
+- Custom webhooks
+
+### Notification Integrations
+
+Configure in `kubernetes/argo-rollouts-install.yaml`:
+- Slack
+- Email
+- PagerDuty
+- Webhooks
+
+---
+
+## Terraform Deployment
+
+### Initialize Infrastructure
+
+```bash
+cd terraform
+
+# Initialize
+terraform init
+
+# Plan
+terraform plan
+
+# Apply
+terraform apply
+
+# Outputs
+terraform output
+```
+
+### Key Resources
+
+- **EKS Cluster**: `eks.tf`
+- **Load Balancer Controller**: `load-balancer-controller.tf`
+- **Argo Rollouts**: `argo-rollouts.tf`
+- **Networking**: `security.tf`
+
+---
+
+## References
+
+### Documentation
+
+- [Argo Rollouts](https://argoproj.github.io/argo-rollouts/)
+- [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/)
+- [Prometheus Operator](https://prometheus-operator.dev/)
+- [Grafana](https://grafana.com/docs/)
+
+### Files Reference
+
+| File | Purpose |
+|------|---------|
+| `kubernetes/rollout-blue-green.yaml` | Blue/Green deployment manifests |
+| `kubernetes/rollout-canary.yaml` | Canary deployment manifests |
+| `kubernetes/analysis-templates.yaml` | Prometheus analysis templates |
+| `kubernetes/services.yaml` | Kubernetes services |
+| `kubernetes/ingress.yaml` | Ingress configurations |
+| `kubernetes/servicemonitors.yaml` | Prometheus ServiceMonitors |
+| `scripts/deploy-blue-green.sh` | Blue/Green deployment script |
+| `scripts/deploy-canary.sh` | Canary deployment script |
+| `scripts/setup-advanced-deployments.sh` | Infrastructure setup |
+| `terraform/load-balancer-controller.tf` | AWS LB Controller |
+| `terraform/argo-rollouts.tf` | Argo Rollouts infrastructure |
+
+---
+
+## Support
+
+For issues or questions:
+1. Check the troubleshooting section
+2. Review Argo Rollouts documentation
+3. Check pod logs and events
+4. Verify Prometheus metrics
+
+---
+
+**Last Updated**: 2025-11-27
+**Version**: 1.0.0

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,0 +1,401 @@
+# Quick Start Guide - Advanced Deployments
+
+This guide provides quick commands for common deployment operations.
+
+## Initial Setup
+
+### 1. Install Prerequisites
+
+```bash
+# Install kubectl
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+chmod +x kubectl
+sudo mv kubectl /usr/local/bin/
+
+# Install helm
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+# Install AWS CLI (for AWS deployments)
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install
+```
+
+### 2. Setup Infrastructure
+
+```bash
+cd scripts
+chmod +x *.sh
+./setup-advanced-deployments.sh
+```
+
+### 3. Configure Terraform (Optional)
+
+```bash
+cd terraform
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your values
+terraform init
+terraform plan
+terraform apply
+```
+
+---
+
+## Deployment Commands
+
+### Blue/Green Deployment
+
+```bash
+# Deploy new version to preview
+./scripts/deploy-blue-green.sh airflow v1.0.0
+
+# Inside the script, you can:
+# - View preview endpoint
+# - Test preview environment
+# - Compare Blue vs Green metrics
+# - Promote to production
+# - Rollback to Blue
+```
+
+### Canary Deployment
+
+```bash
+# Deploy with progressive traffic shifting
+./scripts/deploy-canary.sh airflow v1.0.0
+
+# The script will:
+# - Deploy canary version
+# - Progressively shift traffic (10% → 25% → 50% → 75% → 100%)
+# - Run automated analysis at each step
+# - Auto-rollback on failures
+```
+
+---
+
+## Manual Operations
+
+### Using kubectl-argo-rollouts
+
+```bash
+# List all rollouts
+kubectl argo rollouts list
+
+# Get rollout status
+kubectl argo rollouts get rollout airflow-rollout
+
+# Watch rollout progress
+kubectl argo rollouts get rollout airflow-rollout --watch
+
+# Promote rollout
+kubectl argo rollouts promote airflow-rollout
+
+# Abort rollout
+kubectl argo rollouts abort airflow-rollout
+
+# Rollback to previous version
+kubectl argo rollouts undo airflow-rollout
+
+# Set new image
+kubectl argo rollouts set image airflow-rollout \
+  airflow-webserver=myrepo/airflow-pipeline:v2.0.0
+```
+
+### Using kubectl
+
+```bash
+# Apply rollout manifests
+kubectl apply -f kubernetes/rollout-blue-green.yaml
+kubectl apply -f kubernetes/rollout-canary.yaml
+
+# Get rollouts
+kubectl get rollouts
+
+# Describe rollout
+kubectl describe rollout airflow-rollout
+
+# Get analysis runs
+kubectl get analysisruns
+
+# View analysis details
+kubectl describe analysisrun <analysis-run-name>
+
+# Get pods
+kubectl get pods -l app=pipeline
+```
+
+---
+
+## Monitoring
+
+### Access Dashboards
+
+```bash
+# Argo Rollouts Dashboard
+kubectl port-forward -n argo-rollouts svc/argo-rollouts-dashboard 3100:3100
+# Open: http://localhost:3100
+
+# Grafana
+kubectl port-forward -n monitoring svc/kube-prometheus-grafana 3000:80
+# Open: http://localhost:3000 (admin/admin)
+
+# Prometheus
+kubectl port-forward -n monitoring svc/kube-prometheus-prometheus 9090:9090
+# Open: http://localhost:9090
+```
+
+### View Metrics
+
+```bash
+# Check success rate
+kubectl exec -n monitoring prometheus-0 -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=service:http_requests:success_rate'
+
+# Check error rate
+kubectl exec -n monitoring prometheus-0 -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=service:http_requests:error_rate'
+
+# Check latency
+kubectl exec -n monitoring prometheus-0 -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=service:http_request_duration:p95'
+```
+
+---
+
+## Troubleshooting
+
+### Check Rollout Status
+
+```bash
+kubectl argo rollouts get rollout <rollout-name>
+kubectl describe rollout <rollout-name>
+kubectl get events --sort-by=.metadata.creationTimestamp
+```
+
+### Check Analysis
+
+```bash
+kubectl get analysisruns
+kubectl describe analysisrun <analysis-run-name>
+kubectl logs -n argo-rollouts deployment/argo-rollouts
+```
+
+### Check Services
+
+```bash
+kubectl get svc
+kubectl describe svc <service-name>
+kubectl get endpoints <service-name>
+```
+
+### Check Pods
+
+```bash
+kubectl get pods -l app=pipeline
+kubectl describe pod <pod-name>
+kubectl logs <pod-name>
+kubectl logs <pod-name> --previous  # Previous container logs
+```
+
+### Emergency Rollback
+
+```bash
+# Method 1: Using Argo Rollouts
+kubectl argo rollouts abort <rollout-name>
+kubectl argo rollouts undo <rollout-name>
+
+# Method 2: Using kubectl
+kubectl rollout undo rollout/<rollout-name>
+
+# Method 3: Revert to specific revision
+kubectl argo rollouts undo <rollout-name> --to-revision=2
+```
+
+---
+
+## Common Scenarios
+
+### Scenario 1: Deploy New Version with Auto-Promotion
+
+```bash
+# Apply canary rollout with auto-promotion
+kubectl apply -f kubernetes/rollout-canary.yaml
+
+# Update image (deployment starts automatically)
+kubectl argo rollouts set image airflow-canary-rollout \
+  airflow-webserver=myrepo/airflow-pipeline:v2.0.0
+
+# Watch progress (auto-promotes if analysis passes)
+kubectl argo rollouts get rollout airflow-canary-rollout --watch
+```
+
+### Scenario 2: Deploy with Manual Approval Gates
+
+```bash
+# Deploy blue/green with manual promotion
+kubectl apply -f kubernetes/rollout-blue-green.yaml
+
+# Update to new version
+kubectl argo rollouts set image airflow-rollout \
+  airflow-webserver=myrepo/airflow-pipeline:v2.0.0
+
+# Test preview environment
+kubectl port-forward svc/airflow-webserver-preview 8081:8080
+
+# After testing, promote manually
+kubectl argo rollouts promote airflow-rollout
+```
+
+### Scenario 3: A/B Testing with Header Routing
+
+```bash
+# Apply header-based canary
+kubectl apply -f kubernetes/rollout-canary.yaml
+
+# Internal users get canary version
+curl -H "X-Version: canary" http://your-service.com
+
+# Regular users get stable version
+curl http://your-service.com
+```
+
+### Scenario 4: Emergency Rollback
+
+```bash
+# Immediate abort
+kubectl argo rollouts abort airflow-rollout
+
+# Rollback to previous stable version
+kubectl argo rollouts undo airflow-rollout
+
+# Verify rollback
+kubectl argo rollouts get rollout airflow-rollout
+```
+
+---
+
+## Configuration Files
+
+### Key Files and Their Purpose
+
+| File | Purpose |
+|------|---------|
+| `kubernetes/rollout-blue-green.yaml` | Blue/Green rollout definitions |
+| `kubernetes/rollout-canary.yaml` | Canary rollout definitions |
+| `kubernetes/analysis-templates.yaml` | Prometheus metrics analysis |
+| `kubernetes/services.yaml` | Kubernetes services |
+| `kubernetes/ingress.yaml` | Traffic routing rules |
+| `scripts/deploy-blue-green.sh` | Interactive blue/green deployment |
+| `scripts/deploy-canary.sh` | Interactive canary deployment |
+| `scripts/setup-advanced-deployments.sh` | Infrastructure setup |
+
+### Customize Analysis Templates
+
+Edit `kubernetes/analysis-templates.yaml`:
+
+```yaml
+# Example: Change success rate threshold
+metrics:
+  - name: success-rate
+    successCondition: result >= 0.99  # Change from 0.95 to 0.99
+    failureLimit: 2                    # Reduce from 3 to 2
+```
+
+### Customize Traffic Weights
+
+Edit `kubernetes/rollout-canary.yaml`:
+
+```yaml
+steps:
+  - setWeight: 5    # Start with 5% instead of 10%
+  - pause: {duration: 1m}
+  - setWeight: 15   # Then 15%
+  - pause: {duration: 2m}
+  # ... customize as needed
+```
+
+---
+
+## Health Checks
+
+### Verify Installation
+
+```bash
+# Check Argo Rollouts
+kubectl get pods -n argo-rollouts
+
+# Check Prometheus
+kubectl get pods -n monitoring
+
+# Check Ingress Controller
+kubectl get pods -n ingress-nginx
+
+# Verify all components
+kubectl get all -n argo-rollouts
+kubectl get all -n monitoring
+```
+
+### Test Connectivity
+
+```bash
+# Test Prometheus
+kubectl exec -n monitoring prometheus-0 -- wget -qO- http://localhost:9090/-/healthy
+
+# Test Grafana
+kubectl exec -n monitoring deployment/kube-prometheus-grafana -- wget -qO- http://localhost:3000/api/health
+
+# Test Argo Rollouts
+kubectl exec -n argo-rollouts deployment/argo-rollouts -- wget -qO- http://localhost:8080/healthz
+```
+
+---
+
+## Performance Tuning
+
+### Optimize Canary Steps
+
+For high-traffic services:
+- Start with smaller weights (5%)
+- Use shorter soak times (1-2 minutes)
+- More granular steps (5%, 10%, 20%, 30%, 50%, 100%)
+
+For critical services:
+- Larger initial weight (20%)
+- Longer soak times (5-10 minutes)
+- Fewer steps (20%, 50%, 100%)
+
+### Optimize Analysis
+
+```yaml
+# Fast-moving services
+interval: 15s
+count: 4        # 1 minute total
+
+# Stable services
+interval: 60s
+count: 10       # 10 minutes total
+```
+
+---
+
+## Next Steps
+
+1. Review [DEPLOYMENT_STRATEGIES.md](./DEPLOYMENT_STRATEGIES.md) for detailed documentation
+2. Customize analysis templates for your metrics
+3. Configure Slack notifications
+4. Set up custom dashboards in Grafana
+5. Practice rollback procedures
+6. Configure automated testing in CI/CD
+
+---
+
+## Support & Resources
+
+- **Argo Rollouts Docs**: https://argoproj.github.io/argo-rollouts/
+- **Prometheus Docs**: https://prometheus.io/docs/
+- **Grafana Docs**: https://grafana.com/docs/
+- **Kubectl Cheatsheet**: https://kubernetes.io/docs/reference/kubectl/cheatsheet/
+
+---
+
+**Last Updated**: 2025-11-27

--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@ Congratulations! You have successfully set up the end-to-end data pipeline with 
 ## Example Applications
 
 ```mermaid
+%%{init: {"theme": "default", "themeVariables": { "primaryColor": "#f9f9f9", "fontSize": "14px", "lineColor": "#000000", "textColor": "#000000", "background": "#ffffff"}}}%%
 mindmap
   root((Data Pipeline<br/>Use Cases))
     E-Commerce

--- a/kubernetes/analysis-templates.yaml
+++ b/kubernetes/analysis-templates.yaml
@@ -1,0 +1,249 @@
+---
+# AnalysisTemplate for Success Rate Monitoring
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: success-rate-analysis
+  namespace: default
+spec:
+  metrics:
+    - name: success-rate
+      interval: 30s
+      successCondition: result >= 0.95
+      failureLimit: 3
+      provider:
+        prometheus:
+          address: http://prometheus:9090
+          query: |
+            sum(rate(
+              http_requests_total{status=~"2.."}[5m]
+            )) /
+            sum(rate(
+              http_requests_total[5m]
+            ))
+
+    - name: error-rate
+      interval: 30s
+      successCondition: result <= 0.05
+      failureLimit: 3
+      provider:
+        prometheus:
+          address: http://prometheus:9090
+          query: |
+            sum(rate(
+              http_requests_total{status=~"5.."}[5m]
+            )) /
+            sum(rate(
+              http_requests_total[5m]
+            ))
+
+---
+# AnalysisTemplate for Latency Monitoring
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: latency-analysis
+  namespace: default
+spec:
+  metrics:
+    - name: p95-latency
+      interval: 30s
+      successCondition: result <= 500  # 500ms
+      failureLimit: 3
+      provider:
+        prometheus:
+          address: http://prometheus:9090
+          query: |
+            histogram_quantile(0.95,
+              sum(rate(http_request_duration_milliseconds_bucket[5m])) by (le)
+            )
+
+    - name: p99-latency
+      interval: 30s
+      successCondition: result <= 1000  # 1000ms
+      failureLimit: 3
+      provider:
+        prometheus:
+          address: http://prometheus:9090
+          query: |
+            histogram_quantile(0.99,
+              sum(rate(http_request_duration_milliseconds_bucket[5m])) by (le)
+            )
+
+---
+# AnalysisTemplate for Airflow-specific Metrics
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: airflow-health-analysis
+  namespace: default
+spec:
+  metrics:
+    - name: task-failure-rate
+      interval: 60s
+      successCondition: result <= 0.10  # Max 10% task failure rate
+      failureLimit: 2
+      provider:
+        prometheus:
+          address: http://prometheus:9090
+          query: |
+            sum(rate(airflow_task_failed_total[5m])) /
+            sum(rate(airflow_task_total[5m]))
+
+    - name: scheduler-heartbeat
+      interval: 30s
+      successCondition: result > 0
+      failureLimit: 3
+      provider:
+        prometheus:
+          address: http://prometheus:9090
+          query: |
+            airflow_scheduler_heartbeat
+
+    - name: dag-processing-time
+      interval: 60s
+      successCondition: result <= 30  # Max 30 seconds
+      failureLimit: 2
+      provider:
+        prometheus:
+          address: http://prometheus:9090
+          query: |
+            avg(airflow_dagbag_import_duration_seconds)
+
+---
+# AnalysisTemplate for Kafka Health
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: kafka-health-analysis
+  namespace: default
+spec:
+  metrics:
+    - name: consumer-lag
+      interval: 30s
+      successCondition: result <= 1000  # Max 1000 messages lag
+      failureLimit: 3
+      provider:
+        prometheus:
+          address: http://prometheus:9090
+          query: |
+            sum(kafka_consumer_lag)
+
+    - name: broker-availability
+      interval: 30s
+      successCondition: result == 1  # All brokers must be up
+      failureLimit: 2
+      provider:
+        prometheus:
+          address: http://prometheus:9090
+          query: |
+            min(kafka_server_broker_state)
+
+    - name: under-replicated-partitions
+      interval: 60s
+      successCondition: result == 0
+      failureLimit: 2
+      provider:
+        prometheus:
+          address: http://prometheus:9090
+          query: |
+            sum(kafka_server_replicamanager_underreplicatedpartitions)
+
+---
+# AnalysisTemplate for Spark Job Health
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: spark-job-analysis
+  namespace: default
+spec:
+  metrics:
+    - name: failed-jobs
+      interval: 60s
+      successCondition: result == 0
+      failureLimit: 2
+      provider:
+        prometheus:
+          address: http://prometheus:9090
+          query: |
+            sum(increase(spark_application_failed_jobs[5m]))
+
+    - name: executor-availability
+      interval: 30s
+      successCondition: result >= 2  # At least 2 executors available
+      failureLimit: 3
+      provider:
+        prometheus:
+          address: http://prometheus:9090
+          query: |
+            spark_executor_count
+
+---
+# Combined AnalysisTemplate for Full Health Check
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: complete-health-analysis
+  namespace: default
+spec:
+  args:
+    - name: service-name
+  metrics:
+    - name: success-rate
+      interval: 30s
+      count: 5
+      successCondition: result >= 0.95
+      failureLimit: 2
+      provider:
+        prometheus:
+          address: http://prometheus:9090
+          query: |
+            sum(rate(
+              http_requests_total{service="{{args.service-name}}",status=~"2.."}[2m]
+            )) /
+            sum(rate(
+              http_requests_total{service="{{args.service-name}}"}[2m]
+            ))
+
+    - name: cpu-usage
+      interval: 30s
+      successCondition: result <= 80  # Max 80% CPU
+      failureLimit: 3
+      provider:
+        prometheus:
+          address: http://prometheus:9090
+          query: |
+            avg(rate(container_cpu_usage_seconds_total{pod=~"{{args.service-name}}.*"}[2m])) * 100
+
+    - name: memory-usage
+      interval: 30s
+      successCondition: result <= 85  # Max 85% memory
+      failureLimit: 3
+      provider:
+        prometheus:
+          address: http://prometheus:9090
+          query: |
+            avg(container_memory_working_set_bytes{pod=~"{{args.service-name}}.*"} /
+            container_spec_memory_limit_bytes{pod=~"{{args.service-name}}.*"}) * 100
+
+---
+# Web Analysis using HTTP checks
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: http-health-check
+  namespace: default
+spec:
+  args:
+    - name: url
+  metrics:
+    - name: http-check
+      count: 5
+      interval: 10s
+      successCondition: result == "200"
+      failureLimit: 2
+      provider:
+        web:
+          url: "{{args.url}}/health"
+          timeoutSeconds: 5
+          jsonPath: "{$.status}"

--- a/kubernetes/argo-rollouts-install.yaml
+++ b/kubernetes/argo-rollouts-install.yaml
@@ -1,0 +1,108 @@
+# Argo Rollouts Installation via Helm values
+# Install using: kubectl create namespace argo-rollouts && kubectl apply -n argo-rollouts -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
+# Or using Helm (recommended for production)
+
+---
+# Argo Rollouts ConfigMap for Prometheus Metrics
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argo-rollouts-config
+  namespace: argo-rollouts
+data:
+  # Enable Prometheus metrics
+  metricsPort: "8090"
+
+  # Traffic router plugins configuration
+  trafficRouterPlugins: |
+    - name: "argoproj-labs/gatewayAPI"
+      location: "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/v0.1.0/gateway-api-plugin-linux-amd64"
+
+---
+# ServiceAccount for Argo Rollouts with extended permissions
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo-rollouts
+  namespace: argo-rollouts
+
+---
+# ClusterRole for Argo Rollouts
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argo-rollouts-aggregate
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+      - rollouts/status
+      - rollouts/finalizers
+      - experiments
+      - experiments/status
+      - analysisruns
+      - analysisruns/status
+      - analysistemplates
+      - clusteranalysistemplates
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
+
+---
+# Service for Argo Rollouts Dashboard
+apiVersion: v1
+kind: Service
+metadata:
+  name: argo-rollouts-dashboard
+  namespace: argo-rollouts
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 3100
+      targetPort: 3100
+      protocol: TCP
+      name: dashboard
+  selector:
+    app.kubernetes.io/name: argo-rollouts
+    app.kubernetes.io/component: dashboard
+
+---
+# Argo Rollouts Notification ConfigMap (for Slack, email, etc.)
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argo-rollouts-notification-configmap
+  namespace: argo-rollouts
+data:
+  service.slack: |
+    token: $slack-token
+
+  template.rollout-updated: |
+    message: |
+      Rollout {{.rollout.metadata.name}} has been updated.
+      Revision: {{.rollout.status.currentPodHash}}
+      Phase: {{.rollout.status.phase}}
+
+  template.rollout-aborted: |
+    message: |
+      ⚠️ Rollout {{.rollout.metadata.name}} has been ABORTED!
+      Reason: Analysis failed
+
+  template.rollout-completed: |
+    message: |
+      ✅ Rollout {{.rollout.metadata.name}} completed successfully!
+      New revision: {{.rollout.status.currentPodHash}}
+
+  trigger.on-rollout-completed: |
+    - when: rollout.status.phase == 'Healthy'
+      send: [rollout-completed]
+
+  trigger.on-rollout-aborted: |
+    - when: rollout.status.phase == 'Degraded'
+      send: [rollout-aborted]

--- a/kubernetes/ingress.yaml
+++ b/kubernetes/ingress.yaml
@@ -1,0 +1,143 @@
+---
+# AWS Load Balancer Ingress for Airflow
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: pipeline-ingress
+  namespace: default
+  annotations:
+    # AWS Load Balancer Controller annotations
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: '15'
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '5'
+    alb.ingress.kubernetes.io/healthy-threshold-count: '2'
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: '2'
+
+    # SSL/TLS Configuration (uncomment and configure with your ACM certificate ARN)
+    # alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:region:account-id:certificate/certificate-id
+    # alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    # alb.ingress.kubernetes.io/ssl-redirect: '443'
+
+    # Security
+    alb.ingress.kubernetes.io/security-groups: pipeline-ingress-sg
+
+    # Traffic distribution settings
+    alb.ingress.kubernetes.io/load-balancer-attributes: routing.http2.enabled=true,idle_timeout.timeout_seconds=60
+
+    # Tags for AWS resources
+    alb.ingress.kubernetes.io/tags: Environment=production,Project=data-pipeline,ManagedBy=kubernetes
+
+spec:
+  rules:
+    - host: airflow.yourdomain.com  # Replace with your domain
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: airflow-webserver
+                port:
+                  number: 8080
+
+    - host: spark.yourdomain.com  # Replace with your domain
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: spark-master
+                port:
+                  number: 4040
+
+    - host: grafana.yourdomain.com  # Replace with your domain
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 3000
+
+---
+# Nginx Ingress Controller alternative (for more advanced traffic management)
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: pipeline-nginx-ingress
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.class: nginx
+
+    # Rate limiting
+    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/limit-connections: "10"
+
+    # Circuit breaker configuration
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+
+    # Canary deployment annotations (can be used with standard Nginx Ingress)
+    # nginx.ingress.kubernetes.io/canary: "true"
+    # nginx.ingress.kubernetes.io/canary-weight: "20"
+    # nginx.ingress.kubernetes.io/canary-by-header: "x-canary"
+
+    # Load balancing algorithm
+    nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
+
+    # Enable CORS
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+
+    # SSL/TLS
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+
+spec:
+  tls:
+    - hosts:
+        - airflow.yourdomain.com
+        - spark.yourdomain.com
+        - grafana.yourdomain.com
+      secretName: pipeline-tls-secret
+
+  rules:
+    - host: airflow.yourdomain.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: airflow-webserver
+                port:
+                  number: 8080
+
+    - host: spark.yourdomain.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: spark-master
+                port:
+                  number: 4040
+
+    - host: grafana.yourdomain.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 3000

--- a/kubernetes/rollout-blue-green.yaml
+++ b/kubernetes/rollout-blue-green.yaml
@@ -1,0 +1,251 @@
+---
+# Blue/Green Deployment for Airflow using Argo Rollouts
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: airflow-rollout
+  namespace: default
+  labels:
+    app: pipeline
+    component: airflow
+spec:
+  replicas: 3
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: pipeline
+      component: airflow
+
+  template:
+    metadata:
+      labels:
+        app: pipeline
+        component: airflow
+    spec:
+      containers:
+        - name: airflow-webserver
+          image: myrepo/airflow-pipeline:latest
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: AIRFLOW__CORE__EXECUTOR
+              value: "LocalExecutor"
+            - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
+              value: "postgresql+psycopg2://airflow:airflow@postgres/airflow"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+
+  strategy:
+    blueGreen:
+      # Service that the rollout modifies as the active service
+      activeService: airflow-webserver-active
+
+      # Service that the rollout modifies as the preview service (for testing before promotion)
+      previewService: airflow-webserver-preview
+
+      # Auto promotion after 5 minutes if no manual intervention
+      autoPromotionEnabled: false
+      autoPromotionSeconds: 300
+
+      # Pre-promotion analysis
+      prePromotionAnalysis:
+        templates:
+          - templateName: success-rate-analysis
+          - templateName: latency-analysis
+          - templateName: airflow-health-analysis
+        args:
+          - name: service-name
+            value: airflow-webserver
+
+      # Post-promotion analysis (runs after promotion)
+      postPromotionAnalysis:
+        templates:
+          - templateName: complete-health-analysis
+        args:
+          - name: service-name
+            value: airflow-webserver
+
+      # Scale down old replica set after successful deployment
+      scaleDownDelaySeconds: 300
+      scaleDownDelayRevisionLimit: 2
+
+      # Anti-affinity for blue/green pods
+      antiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution: {}
+
+---
+# Active Service (receives production traffic)
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-webserver-active
+  namespace: default
+  labels:
+    app: pipeline
+    component: airflow
+    role: active
+spec:
+  type: LoadBalancer
+  selector:
+    app: pipeline
+    component: airflow
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+
+---
+# Preview Service (for testing new version before promotion)
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-webserver-preview
+  namespace: default
+  labels:
+    app: pipeline
+    component: airflow
+    role: preview
+spec:
+  type: ClusterIP
+  selector:
+    app: pipeline
+    component: airflow
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+
+---
+# Blue/Green Deployment for Kafka (stateful workload example)
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: kafka-rollout
+  namespace: default
+  labels:
+    app: pipeline
+    component: kafka
+spec:
+  replicas: 3
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: pipeline
+      component: kafka
+
+  template:
+    metadata:
+      labels:
+        app: pipeline
+        component: kafka
+    spec:
+      containers:
+        - name: kafka
+          image: myrepo/kafka-pipeline:latest
+          ports:
+            - name: broker
+              containerPort: 9092
+            - name: jmx
+              containerPort: 9999
+          env:
+            - name: KAFKA_BROKER_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KAFKA_ZOOKEEPER_CONNECT
+              value: "zookeeper:2181"
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: "PLAINTEXT://kafka:9092"
+          livenessProbe:
+            tcpSocket:
+              port: 9092
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: 9092
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 2Gi
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+
+  strategy:
+    blueGreen:
+      activeService: kafka-broker-active
+      previewService: kafka-broker-preview
+      autoPromotionEnabled: false
+      autoPromotionSeconds: 600  # 10 minutes for Kafka
+
+      prePromotionAnalysis:
+        templates:
+          - templateName: kafka-health-analysis
+        args:
+          - name: service-name
+            value: kafka-broker
+
+      scaleDownDelaySeconds: 600  # Keep old version longer for Kafka
+      scaleDownDelayRevisionLimit: 1
+
+---
+# Kafka Active Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-broker-active
+  namespace: default
+spec:
+  type: ClusterIP
+  selector:
+    app: pipeline
+    component: kafka
+  ports:
+    - name: broker
+      port: 9092
+      targetPort: 9092
+
+---
+# Kafka Preview Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-broker-preview
+  namespace: default
+spec:
+  type: ClusterIP
+  selector:
+    app: pipeline
+    component: kafka
+  ports:
+    - name: broker
+      port: 9092
+      targetPort: 9092

--- a/kubernetes/rollout-canary.yaml
+++ b/kubernetes/rollout-canary.yaml
@@ -1,0 +1,410 @@
+---
+# Canary Deployment for Airflow with Progressive Traffic Shifting
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: airflow-canary-rollout
+  namespace: default
+  labels:
+    app: pipeline
+    component: airflow
+    strategy: canary
+spec:
+  replicas: 5
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: pipeline
+      component: airflow
+
+  template:
+    metadata:
+      labels:
+        app: pipeline
+        component: airflow
+    spec:
+      containers:
+        - name: airflow-webserver
+          image: myrepo/airflow-pipeline:latest
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: AIRFLOW__CORE__EXECUTOR
+              value: "LocalExecutor"
+            - name: AIRFLOW__METRICS__STATSD_ON
+              value: "True"
+            - name: AIRFLOW__METRICS__STATSD_HOST
+              value: "prometheus-statsd-exporter"
+            - name: AIRFLOW__METRICS__STATSD_PORT
+              value: "9125"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+
+  strategy:
+    canary:
+      # Stable service receives baseline traffic
+      stableService: airflow-stable
+
+      # Canary service receives canary traffic
+      canaryService: airflow-canary
+
+      # Traffic routing (using Nginx Ingress, ALB, or Istio)
+      trafficRouting:
+        nginx:
+          stableIngress: pipeline-nginx-ingress
+          # Additional headers can be used for controlled testing
+          additionalIngressAnnotations:
+            canary-by-header: X-Canary
+            canary-by-header-value: "insider"
+
+      # Progressive traffic shift steps
+      steps:
+        # Step 1: Deploy canary with 10% traffic
+        - setWeight: 10
+        - pause:
+            duration: 2m
+
+        # Step 2: Run analysis at 10%
+        - analysis:
+            templates:
+              - templateName: success-rate-analysis
+              - templateName: latency-analysis
+            args:
+              - name: service-name
+                value: airflow-canary
+
+        # Step 3: Increase to 25% if analysis passes
+        - setWeight: 25
+        - pause:
+            duration: 3m
+
+        # Step 4: Run analysis at 25%
+        - analysis:
+            templates:
+              - templateName: complete-health-analysis
+              - templateName: airflow-health-analysis
+            args:
+              - name: service-name
+                value: airflow-canary
+
+        # Step 5: Increase to 50%
+        - setWeight: 50
+        - pause:
+            duration: 5m
+
+        # Step 6: Run comprehensive analysis at 50%
+        - analysis:
+            templates:
+              - templateName: success-rate-analysis
+              - templateName: latency-analysis
+              - templateName: airflow-health-analysis
+            args:
+              - name: service-name
+                value: airflow-canary
+
+        # Step 7: Increase to 75%
+        - setWeight: 75
+        - pause:
+            duration: 3m
+
+        # Step 8: Final analysis before full promotion
+        - analysis:
+            templates:
+              - templateName: complete-health-analysis
+            args:
+              - name: service-name
+                value: airflow-canary
+
+        # Step 9: Full promotion to 100%
+        - setWeight: 100
+
+      # Analysis configuration
+      analysis:
+        # Run background analysis throughout the rollout
+        templates:
+          - templateName: success-rate-analysis
+          - templateName: error-rate
+        args:
+          - name: service-name
+            value: airflow-canary
+        startingStep: 1  # Start analysis from step 1
+
+      # Anti-affinity to spread pods across nodes
+      antiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                    - pipeline
+
+---
+# Stable Service (receives production traffic)
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-stable
+  namespace: default
+  labels:
+    app: pipeline
+    component: airflow
+    role: stable
+spec:
+  type: LoadBalancer
+  selector:
+    app: pipeline
+    component: airflow
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+
+---
+# Canary Service (receives canary traffic)
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-canary
+  namespace: default
+  labels:
+    app: pipeline
+    component: airflow
+    role: canary
+spec:
+  type: ClusterIP
+  selector:
+    app: pipeline
+    component: airflow
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+
+---
+# Advanced Canary with Experiment (A/B Testing)
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: spark-canary-experiment
+  namespace: default
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: pipeline
+      component: spark
+
+  template:
+    metadata:
+      labels:
+        app: pipeline
+        component: spark
+    spec:
+      containers:
+        - name: spark-master
+          image: myrepo/spark-pipeline:latest
+          ports:
+            - containerPort: 4040
+            - containerPort: 7077
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 2Gi
+            limits:
+              cpu: 4000m
+              memory: 8Gi
+
+  strategy:
+    canary:
+      stableService: spark-stable
+      canaryService: spark-canary
+
+      # Advanced: Use experiments for A/B testing
+      experiments:
+        - name: spark-performance-test
+          templates:
+            - name: baseline
+              specRef: stable
+              replicas: 2
+            - name: optimized
+              specRef: canary
+              replicas: 2
+          analyses:
+            - name: performance-comparison
+              templateName: spark-job-analysis
+          duration: 10m
+
+      steps:
+        - setWeight: 20
+        - pause: {duration: 5m}
+        - experiment:
+            templates:
+              - name: spark-perf-experiment
+                specRef: canary
+            analyses:
+              - name: spark-analysis
+                templateName: spark-job-analysis
+        - setWeight: 50
+        - pause: {duration: 10m}
+        - setWeight: 100
+
+---
+# Canary with Manual Gates and Notifications
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: kafka-canary-manual
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: pipeline
+      component: kafka
+
+  template:
+    metadata:
+      labels:
+        app: pipeline
+        component: kafka
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9999"
+    spec:
+      containers:
+        - name: kafka
+          image: myrepo/kafka-pipeline:latest
+          ports:
+            - name: broker
+              containerPort: 9092
+            - name: jmx
+              containerPort: 9999
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 2Gi
+
+  strategy:
+    canary:
+      stableService: kafka-stable
+      canaryService: kafka-canary
+
+      # Manual approval gates
+      steps:
+        - setWeight: 10
+        - pause: {duration: 5m}
+
+        # Manual gate for approval
+        - pause: {}  # Indefinite pause - requires manual promotion
+
+        - setWeight: 25
+        - analysis:
+            templates:
+              - templateName: kafka-health-analysis
+
+        - pause: {}  # Another manual gate
+
+        - setWeight: 50
+        - pause: {duration: 10m}
+
+        - pause: {}  # Final approval before full rollout
+
+        - setWeight: 100
+
+      # Max duration before auto-rollback
+      maxSurge: 1
+      maxUnavailable: 0
+
+      # Abort conditions (automatic rollback triggers)
+      abortScaleDownDelaySeconds: 30
+
+---
+# Traffic Split Canary (Header-based routing)
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: api-header-canary
+  namespace: default
+  annotations:
+    notifications.argoproj.io/subscribe.on-rollout-completed.slack: "deployments-channel"
+    notifications.argoproj.io/subscribe.on-rollout-aborted.slack: "alerts-channel"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: api
+      tier: backend
+
+  template:
+    metadata:
+      labels:
+        app: api
+        tier: backend
+    spec:
+      containers:
+        - name: backend
+          image: myrepo/backend:latest
+          ports:
+            - containerPort: 8080
+
+  strategy:
+    canary:
+      canaryService: api-canary
+      stableService: api-stable
+
+      trafficRouting:
+        managedRoutes:
+          - name: header-route
+        nginx:
+          stableIngress: api-ingress
+          additionalIngressAnnotations:
+            # Route users with X-Version: canary header to canary
+            canary-by-header: X-Version
+            canary-by-header-value: canary
+
+      steps:
+        # Phase 1: Internal testing only (header-based)
+        - setHeaderRoute:
+            name: header-route
+            match:
+              - headerName: X-Version
+                headerValue:
+                  exact: canary
+        - pause: {duration: 10m}
+
+        # Phase 2: 5% of general traffic
+        - setWeight: 5
+        - pause: {duration: 5m}
+
+        # Phase 3: Progressive rollout
+        - setWeight: 20
+        - pause: {duration: 5m}
+        - setWeight: 40
+        - pause: {duration: 5m}
+        - setWeight: 60
+        - pause: {duration: 5m}
+        - setWeight: 80
+        - pause: {duration: 3m}
+        - setWeight: 100

--- a/kubernetes/servicemonitors.yaml
+++ b/kubernetes/servicemonitors.yaml
@@ -1,0 +1,353 @@
+---
+# ServiceMonitor for Airflow metrics
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: airflow-metrics
+  namespace: default
+  labels:
+    app: pipeline
+    component: airflow
+    prometheus: kube-prometheus
+spec:
+  selector:
+    matchLabels:
+      app: pipeline
+      component: airflow
+  endpoints:
+    - port: http
+      interval: 30s
+      path: /admin/metrics
+      scheme: http
+    - port: statsd
+      interval: 30s
+      path: /metrics
+      scheme: http
+
+---
+# ServiceMonitor for Kafka JMX metrics
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kafka-metrics
+  namespace: default
+  labels:
+    app: pipeline
+    component: kafka
+spec:
+  selector:
+    matchLabels:
+      app: pipeline
+      component: kafka
+  endpoints:
+    - port: jmx
+      interval: 30s
+      path: /metrics
+      scheme: http
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+
+---
+# ServiceMonitor for Spark metrics
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: spark-metrics
+  namespace: default
+  labels:
+    app: pipeline
+    component: spark
+spec:
+  selector:
+    matchLabels:
+      app: pipeline
+      component: spark
+  endpoints:
+    - port: spark-ui
+      interval: 30s
+      path: /metrics/prometheus
+      scheme: http
+    - port: metrics
+      interval: 30s
+      path: /metrics
+      scheme: http
+
+---
+# ServiceMonitor for MongoDB exporter
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: mongodb-metrics
+  namespace: default
+  labels:
+    app: pipeline
+    component: mongodb
+spec:
+  selector:
+    matchLabels:
+      app: pipeline
+      component: mongodb
+  endpoints:
+    - port: metrics
+      interval: 30s
+      path: /metrics
+
+---
+# ServiceMonitor for Prometheus itself
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prometheus
+  namespace: default
+  labels:
+    app: monitoring
+    component: prometheus
+spec:
+  selector:
+    matchLabels:
+      app: monitoring
+      component: prometheus
+  endpoints:
+    - port: http
+      interval: 30s
+      path: /metrics
+
+---
+# ServiceMonitor for Grafana
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: grafana
+  namespace: default
+  labels:
+    app: monitoring
+    component: grafana
+spec:
+  selector:
+    matchLabels:
+      app: monitoring
+      component: grafana
+  endpoints:
+    - port: http
+      interval: 30s
+      path: /metrics
+
+---
+# PodMonitor for all pipeline pods (alternative to ServiceMonitor)
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: pipeline-pods
+  namespace: default
+  labels:
+    app: pipeline
+spec:
+  selector:
+    matchLabels:
+      app: pipeline
+  podMetricsEndpoints:
+    - port: metrics
+      interval: 30s
+      path: /metrics
+    - port: http
+      interval: 30s
+      path: /metrics
+
+---
+# PrometheusRule for Deployment Alerts
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: deployment-alerts
+  namespace: default
+  labels:
+    prometheus: kube-prometheus
+    role: alert-rules
+spec:
+  groups:
+    - name: deployment.rules
+      interval: 30s
+      rules:
+        # High error rate alert
+        - alert: HighErrorRate
+          expr: |
+            sum(rate(http_requests_total{status=~"5.."}[5m])) by (service) /
+            sum(rate(http_requests_total[5m])) by (service) > 0.05
+          for: 5m
+          labels:
+            severity: critical
+            component: deployment
+          annotations:
+            summary: "High error rate detected for {{ $labels.service }}"
+            description: "Error rate is {{ $value | humanizePercentage }} for service {{ $labels.service }}"
+
+        # High latency alert
+        - alert: HighLatency
+          expr: |
+            histogram_quantile(0.95,
+              sum(rate(http_request_duration_milliseconds_bucket[5m])) by (le, service)
+            ) > 1000
+          for: 10m
+          labels:
+            severity: warning
+            component: deployment
+          annotations:
+            summary: "High latency detected for {{ $labels.service }}"
+            description: "P95 latency is {{ $value }}ms for service {{ $labels.service }}"
+
+        # Rollout degraded
+        - alert: RolloutDegraded
+          expr: |
+            argo_rollouts_phase{phase="Degraded"} == 1
+          for: 2m
+          labels:
+            severity: critical
+            component: deployment
+          annotations:
+            summary: "Rollout {{ $labels.name }} is degraded"
+            description: "Rollout {{ $labels.name }} in namespace {{ $labels.namespace }} is in Degraded state"
+
+        # Analysis run failed
+        - alert: AnalysisRunFailed
+          expr: |
+            argo_rollouts_analysis_run_phase{phase="Failed"} == 1
+          for: 1m
+          labels:
+            severity: critical
+            component: deployment
+          annotations:
+            summary: "Analysis run {{ $labels.name }} failed"
+            description: "Analysis run {{ $labels.name }} for rollout {{ $labels.rollout }} failed"
+
+        # Airflow task failure rate
+        - alert: AirflowHighTaskFailureRate
+          expr: |
+            sum(rate(airflow_task_failed_total[10m])) /
+            sum(rate(airflow_task_total[10m])) > 0.10
+          for: 5m
+          labels:
+            severity: warning
+            component: airflow
+          annotations:
+            summary: "High Airflow task failure rate"
+            description: "Task failure rate is {{ $value | humanizePercentage }}"
+
+        # Kafka consumer lag
+        - alert: KafkaHighConsumerLag
+          expr: |
+            kafka_consumer_lag > 1000
+          for: 5m
+          labels:
+            severity: warning
+            component: kafka
+          annotations:
+            summary: "High Kafka consumer lag"
+            description: "Consumer lag is {{ $value }} messages for topic {{ $labels.topic }}"
+
+        # Spark job failures
+        - alert: SparkJobFailures
+          expr: |
+            increase(spark_application_failed_jobs[5m]) > 0
+          for: 1m
+          labels:
+            severity: critical
+            component: spark
+          annotations:
+            summary: "Spark job failures detected"
+            description: "{{ $value }} Spark jobs failed in the last 5 minutes"
+
+        # Pod not ready
+        - alert: PodNotReady
+          expr: |
+            kube_pod_status_phase{phase!~"Running|Succeeded"} == 1
+          for: 5m
+          labels:
+            severity: warning
+            component: kubernetes
+          annotations:
+            summary: "Pod {{ $labels.pod }} not ready"
+            description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} is in {{ $labels.phase }} phase"
+
+        # High CPU usage during canary
+        - alert: CanaryHighCPU
+          expr: |
+            avg(rate(container_cpu_usage_seconds_total{pod=~".*-canary-.*"}[5m])) by (pod) * 100 > 80
+          for: 5m
+          labels:
+            severity: warning
+            component: deployment
+          annotations:
+            summary: "Canary pod {{ $labels.pod }} has high CPU usage"
+            description: "CPU usage is {{ $value }}% for canary pod {{ $labels.pod }}"
+
+        # High memory usage during canary
+        - alert: CanaryHighMemory
+          expr: |
+            avg(container_memory_working_set_bytes{pod=~".*-canary-.*"} /
+            container_spec_memory_limit_bytes{pod=~".*-canary-.*"}) by (pod) * 100 > 85
+          for: 5m
+          labels:
+            severity: warning
+            component: deployment
+          annotations:
+            summary: "Canary pod {{ $labels.pod }} has high memory usage"
+            description: "Memory usage is {{ $value }}% for canary pod {{ $labels.pod }}"
+
+---
+# PrometheusRule for Recording Rules (pre-aggregated metrics)
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: deployment-recording-rules
+  namespace: default
+  labels:
+    prometheus: kube-prometheus
+    role: recording-rules
+spec:
+  groups:
+    - name: deployment.recording
+      interval: 30s
+      rules:
+        # Success rate by service
+        - record: service:http_requests:success_rate
+          expr: |
+            sum(rate(http_requests_total{status=~"2.."}[5m])) by (service) /
+            sum(rate(http_requests_total[5m])) by (service)
+
+        # Error rate by service
+        - record: service:http_requests:error_rate
+          expr: |
+            sum(rate(http_requests_total{status=~"5.."}[5m])) by (service) /
+            sum(rate(http_requests_total[5m])) by (service)
+
+        # P95 latency by service
+        - record: service:http_request_duration:p95
+          expr: |
+            histogram_quantile(0.95,
+              sum(rate(http_request_duration_milliseconds_bucket[5m])) by (le, service)
+            )
+
+        # P99 latency by service
+        - record: service:http_request_duration:p99
+          expr: |
+            histogram_quantile(0.99,
+              sum(rate(http_request_duration_milliseconds_bucket[5m])) by (le, service)
+            )
+
+        # Request rate by service
+        - record: service:http_requests:rate
+          expr: |
+            sum(rate(http_requests_total[5m])) by (service)
+
+        # Rollout health status
+        - record: rollout:health:status
+          expr: |
+            argo_rollouts_phase{phase="Healthy"} == 1
+
+        # Canary weight
+        - record: rollout:canary:weight
+          expr: |
+            argo_rollouts_info_replicas_desired{rollout=~".*-canary.*"}

--- a/kubernetes/services.yaml
+++ b/kubernetes/services.yaml
@@ -1,0 +1,178 @@
+---
+# Airflow Web UI Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-webserver
+  namespace: default
+  labels:
+    app: pipeline
+    component: airflow
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+spec:
+  type: LoadBalancer
+  selector:
+    app: pipeline
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  sessionAffinity: ClientIP
+
+---
+# Kafka Broker Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-broker
+  namespace: default
+  labels:
+    app: pipeline
+    component: kafka
+spec:
+  type: ClusterIP
+  selector:
+    app: pipeline
+  ports:
+    - name: broker
+      port: 9092
+      targetPort: 9092
+      protocol: TCP
+    - name: jmx
+      port: 9999
+      targetPort: 9999
+      protocol: TCP
+
+---
+# Spark Master Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: spark-master
+  namespace: default
+  labels:
+    app: pipeline
+    component: spark
+spec:
+  type: ClusterIP
+  selector:
+    app: pipeline
+  ports:
+    - name: spark-ui
+      port: 4040
+      targetPort: 4040
+      protocol: TCP
+    - name: spark-master
+      port: 7077
+      targetPort: 7077
+      protocol: TCP
+
+---
+# MongoDB Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  namespace: default
+  labels:
+    app: pipeline
+    component: mongodb
+spec:
+  type: ClusterIP
+  selector:
+    app: pipeline
+  ports:
+    - name: mongo
+      port: 27017
+      targetPort: 27017
+      protocol: TCP
+
+---
+# Hadoop NameNode Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: hadoop-namenode
+  namespace: default
+  labels:
+    app: pipeline
+    component: hadoop
+spec:
+  type: ClusterIP
+  selector:
+    app: pipeline
+  ports:
+    - name: namenode-ui
+      port: 50070
+      targetPort: 50070
+      protocol: TCP
+    - name: namenode-rpc
+      port: 9000
+      targetPort: 9000
+      protocol: TCP
+
+---
+# InfluxDB Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: influxdb
+  namespace: default
+  labels:
+    app: pipeline
+    component: influxdb
+spec:
+  type: ClusterIP
+  selector:
+    app: pipeline
+  ports:
+    - name: http
+      port: 8086
+      targetPort: 8086
+      protocol: TCP
+
+---
+# Prometheus Service (for monitoring)
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: default
+  labels:
+    app: monitoring
+    component: prometheus
+spec:
+  type: ClusterIP
+  selector:
+    app: monitoring
+    component: prometheus
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 9090
+      protocol: TCP
+
+---
+# Grafana Service (for visualization)
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: default
+  labels:
+    app: monitoring
+    component: grafana
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+spec:
+  type: LoadBalancer
+  selector:
+    app: monitoring
+    component: grafana
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+      protocol: TCP

--- a/monitoring/grafana-deployment-dashboards.json
+++ b/monitoring/grafana-deployment-dashboards.json
@@ -1,0 +1,288 @@
+{
+  "dashboard": {
+    "title": "Advanced Deployment Monitoring",
+    "tags": ["deployment", "rollouts", "canary", "blue-green"],
+    "timezone": "browser",
+    "schemaVersion": 16,
+    "version": 1,
+    "refresh": "30s",
+    "panels": [
+      {
+        "id": 1,
+        "title": "Rollout Status Overview",
+        "type": "stat",
+        "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+        "targets": [
+          {
+            "expr": "count(argo_rollouts_phase{phase=\"Healthy\"})",
+            "legendFormat": "Healthy Rollouts",
+            "refId": "A"
+          },
+          {
+            "expr": "count(argo_rollouts_phase{phase=\"Progressing\"})",
+            "legendFormat": "Progressing Rollouts",
+            "refId": "B"
+          },
+          {
+            "expr": "count(argo_rollouts_phase{phase=\"Degraded\"})",
+            "legendFormat": "Degraded Rollouts",
+            "refId": "C"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {"value": 0, "color": "green"},
+                {"value": 1, "color": "red"}
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 2,
+        "title": "Canary Traffic Weight",
+        "type": "gauge",
+        "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+        "targets": [
+          {
+            "expr": "argo_rollouts_info_replicas_desired{rollout=~\".*-canary.*\"} / argo_rollouts_info_replicas_desired * 100",
+            "legendFormat": "{{ rollout }}",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent",
+            "min": 0,
+            "max": 100,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {"value": 0, "color": "green"},
+                {"value": 50, "color": "yellow"},
+                {"value": 75, "color": "orange"}
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 3,
+        "title": "Success Rate Comparison (Stable vs Canary)",
+        "type": "timeseries",
+        "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+        "targets": [
+          {
+            "expr": "sum(rate(http_requests_total{service=~\".*-stable\",status=~\"2..\"}[5m])) / sum(rate(http_requests_total{service=~\".*-stable\"}[5m]))",
+            "legendFormat": "Stable - Success Rate",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(rate(http_requests_total{service=~\".*-canary\",status=~\"2..\"}[5m])) / sum(rate(http_requests_total{service=~\".*-canary\"}[5m]))",
+            "legendFormat": "Canary - Success Rate",
+            "refId": "B"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percentunit",
+            "min": 0,
+            "max": 1
+          }
+        }
+      },
+      {
+        "id": 4,
+        "title": "Latency Comparison (P95)",
+        "type": "timeseries",
+        "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_milliseconds_bucket{service=~\".*-stable\"}[5m])) by (le))",
+            "legendFormat": "Stable - P95 Latency",
+            "refId": "A"
+          },
+          {
+            "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_milliseconds_bucket{service=~\".*-canary\"}[5m])) by (le))",
+            "legendFormat": "Canary - P95 Latency",
+            "refId": "B"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "ms"
+          }
+        }
+      },
+      {
+        "id": 5,
+        "title": "Error Rate Comparison",
+        "type": "timeseries",
+        "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+        "targets": [
+          {
+            "expr": "sum(rate(http_requests_total{service=~\".*-stable\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{service=~\".*-stable\"}[5m]))",
+            "legendFormat": "Stable - Error Rate",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(rate(http_requests_total{service=~\".*-canary\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{service=~\".*-canary\"}[5m]))",
+            "legendFormat": "Canary - Error Rate",
+            "refId": "B"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percentunit",
+            "min": 0
+          }
+        }
+      },
+      {
+        "id": 6,
+        "title": "Analysis Run Status",
+        "type": "table",
+        "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+        "targets": [
+          {
+            "expr": "argo_rollouts_analysis_run_phase",
+            "format": "table",
+            "instant": true,
+            "refId": "A"
+          }
+        ],
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {},
+              "indexByName": {},
+              "renameByName": {
+                "name": "Analysis Run",
+                "namespace": "Namespace",
+                "phase": "Phase",
+                "rollout": "Rollout"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": 7,
+        "title": "CPU Usage (Stable vs Canary)",
+        "type": "timeseries",
+        "gridPos": {"h": 8, "w": 12, "x": 0, "y": 20},
+        "targets": [
+          {
+            "expr": "avg(rate(container_cpu_usage_seconds_total{pod=~\".*-stable-.*\"}[5m])) by (pod) * 100",
+            "legendFormat": "Stable - {{ pod }}",
+            "refId": "A"
+          },
+          {
+            "expr": "avg(rate(container_cpu_usage_seconds_total{pod=~\".*-canary-.*\"}[5m])) by (pod) * 100",
+            "legendFormat": "Canary - {{ pod }}",
+            "refId": "B"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent"
+          }
+        }
+      },
+      {
+        "id": 8,
+        "title": "Memory Usage (Stable vs Canary)",
+        "type": "timeseries",
+        "gridPos": {"h": 8, "w": 12, "x": 12, "y": 20},
+        "targets": [
+          {
+            "expr": "avg(container_memory_working_set_bytes{pod=~\".*-stable-.*\"} / container_spec_memory_limit_bytes{pod=~\".*-stable-.*\"}) by (pod) * 100",
+            "legendFormat": "Stable - {{ pod }}",
+            "refId": "A"
+          },
+          {
+            "expr": "avg(container_memory_working_set_bytes{pod=~\".*-canary-.*\"} / container_spec_memory_limit_bytes{pod=~\".*-canary-.*\"}) by (pod) * 100",
+            "legendFormat": "Canary - {{ pod }}",
+            "refId": "B"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent"
+          }
+        }
+      },
+      {
+        "id": 9,
+        "title": "Deployment Timeline",
+        "type": "timeseries",
+        "gridPos": {"h": 6, "w": 24, "x": 0, "y": 28},
+        "targets": [
+          {
+            "expr": "changes(argo_rollouts_info_replicas_updated[30m])",
+            "legendFormat": "{{ rollout }} - Deployment Events",
+            "refId": "A"
+          }
+        ]
+      },
+      {
+        "id": 10,
+        "title": "Airflow Task Success Rate",
+        "type": "timeseries",
+        "gridPos": {"h": 8, "w": 8, "x": 0, "y": 34},
+        "targets": [
+          {
+            "expr": "sum(rate(airflow_task_total[5m])) - sum(rate(airflow_task_failed_total[5m])) / sum(rate(airflow_task_total[5m]))",
+            "legendFormat": "Success Rate",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percentunit"
+          }
+        }
+      },
+      {
+        "id": 11,
+        "title": "Kafka Consumer Lag",
+        "type": "timeseries",
+        "gridPos": {"h": 8, "w": 8, "x": 8, "y": 34},
+        "targets": [
+          {
+            "expr": "sum(kafka_consumer_lag) by (topic)",
+            "legendFormat": "{{ topic }}",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short"
+          }
+        }
+      },
+      {
+        "id": 12,
+        "title": "Spark Job Status",
+        "type": "timeseries",
+        "gridPos": {"h": 8, "w": 8, "x": 16, "y": 34},
+        "targets": [
+          {
+            "expr": "sum(increase(spark_application_completed_jobs[5m]))",
+            "legendFormat": "Completed Jobs",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(increase(spark_application_failed_jobs[5m]))",
+            "legendFormat": "Failed Jobs",
+            "refId": "B"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/sample_dotnet_backend/Dockerfile
+++ b/sample_dotnet_backend/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /src
 COPY ["src/DataPipelineApi/DataPipelineApi.csproj","DataPipelineApi/"]
 RUN dotnet restore "DataPipelineApi/DataPipelineApi.csproj"
 COPY src/DataPipelineApi/. ./DataPipelineApi
+COPY appsettings.json DataPipelineApi/appsettings.json
 WORKDIR /src/DataPipelineApi
 RUN dotnet publish -c Release -o /app/publish
 

--- a/sample_dotnet_backend/README.md
+++ b/sample_dotnet_backend/README.md
@@ -1,0 +1,41 @@
+# Sample .NET Backend for the E2E Data Pipeline
+
+This project exposes a production-ready API that orchestrates the pipeline components (MySQL, PostgreSQL, MinIO, Kafka, Airflow, Great Expectations, Atlas, MLflow, GitHub Actions).
+
+## Capabilities
+- Batch ingestion: read from MySQL, persist raw JSON to MinIO, optionally run Great Expectations, and trigger the batch Airflow DAG.
+- Streaming: produce enriched events to Kafka and trigger the streaming Airflow DAG.
+- Governance & ML: register lineage to Atlas and start MLflow runs.
+- CI/CD: trigger GitHub Actions workflows for pipeline deployments.
+- Observability: structured health checks for every dependency, HTTP request logging, consistent error responses, forwarded header support, HSTS (non-dev), response compression, and request correlation IDs (`X-Request-ID`).
+
+## Configuration
+All settings live in `appsettings.json` and can be overridden via environment variables. Important keys:
+- `ConnectionStrings.MySql` / `ConnectionStrings.Postgres` and `CommandTimeoutSeconds`
+- `Minio.Endpoint`, `AccessKey`, `SecretKey`, `BucketRaw`, `BucketProcessed`
+- `Kafka.BootstrapServers`, `Topic`, `ClientId`
+- `Airflow.BaseUrl`, `Username`, `Password`, `BatchDagId`, `StreamingDagId`
+- `GreatExpectations.CliPath`, `TimeoutSeconds`
+- `Atlas.Endpoint`, `Username`, `Password`
+- `MLflow.TrackingUri`, `RequestTimeoutSeconds`
+- `GitHub.ActionsApi`, `Token`, `UserAgent`
+
+## Running locally
+```bash
+dotnet restore src/DataPipelineApi/DataPipelineApi.csproj
+dotnet run --project src/DataPipelineApi/DataPipelineApi.csproj
+# or build the container
+docker build -t data-pipeline-api sample_dotnet_backend
+docker run -p 8080:80 --env-file .env data-pipeline-api
+```
+
+## Key endpoints
+- `POST /api/batch/ingest` – body: `{ "sourceTable": "table", "destinationPrefix": "...", "limit": 100, "triggerAirflow": true, "runGreatExpectations": true }`
+- `POST /api/stream/produce` – body: `{ "partition": 0, "payload": { ... } }`
+- `POST /api/stream/run` – trigger streaming DAG
+- `POST /api/governance/lineage` – Atlas lineage payload
+- `POST /api/ml/run` – query: `expId`, `name`
+- `POST /api/ci/trigger` – query: `wf`, `branch`
+- `GET  /api/monitor/health` or `/health` – dependency health map
+
+Swagger is available at `/swagger` in Development.

--- a/sample_dotnet_backend/appsettings.json
+++ b/sample_dotnet_backend/appsettings.json
@@ -1,26 +1,34 @@
 {
   "ConnectionStrings": {
     "MySql": "Server=mysql;Database=source_db;User=user;Password=pass;",
-    "Postgres": "Host=postgres;Database=processed_db;Username=user;Password=pass;"
+    "Postgres": "Host=postgres;Database=processed_db;Username=user;Password=pass;",
+    "CommandTimeoutSeconds": 30
   },
   "Minio": {
     "Endpoint": "minio:9000",
     "AccessKey": "minio",
     "SecretKey": "minio123",
     "BucketRaw": "raw-data",
-    "BucketProcessed": "processed-data"
+    "BucketProcessed": "processed-data",
+    "MaxUploadRetries": 2
   },
   "Kafka": {
     "BootstrapServers": "kafka:9092",
-    "Topic": "events"
+    "Topic": "events",
+    "ClientId": "data-pipeline-api",
+    "MessageTimeoutMs": 5000
   },
   "Airflow": {
     "BaseUrl": "http://airflow:8080/api/v1",
     "Username": "airflow_user",
-    "Password": "airflow_pass"
+    "Password": "airflow_pass",
+    "BatchDagId": "batch_ingestion_dag",
+    "StreamingDagId": "streaming_monitoring_dag",
+    "RequestTimeoutSeconds": 30
   },
   "GreatExpectations": {
-    "CliPath": "/app/ge/bin/great_expectations"
+    "CliPath": "/app/ge/bin/great_expectations",
+    "TimeoutSeconds": 300
   },
   "Atlas": {
     "Endpoint": "http://atlas:21000/api/atlas/v2",
@@ -28,10 +36,12 @@
     "Password": "admin"
   },
   "MLflow": {
-    "TrackingUri": "http://mlflow:5000"
+    "TrackingUri": "http://mlflow:5000",
+    "RequestTimeoutSeconds": 30
   },
   "GitHub": {
     "ActionsApi": "https://api.github.com/repos/hoangsonww/data-pipeline-api/actions/workflows",
-    "Token": ""
+    "Token": "",
+    "UserAgent": "data-pipeline-api"
   }
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Controllers/CIController.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Controllers/CIController.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using DataPipelineApi.Services;
 
@@ -10,9 +12,9 @@ public class CIController : ControllerBase
   public CIController(ICIService ci) => _ci = ci;
 
   [HttpPost("trigger")]
-  public async Task<IActionResult> Trigger([FromQuery]string wf, [FromQuery]string branch)
+  public async Task<IActionResult> Trigger([FromQuery] string wf, [FromQuery] string branch, CancellationToken cancellationToken)
   {
-    var res = await _ci.TriggerWorkflowAsync(wf, branch);
+    var res = await _ci.TriggerWorkflowAsync(wf, branch, cancellationToken);
     return Ok(new { result = res });
   }
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Controllers/GovernanceController.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Controllers/GovernanceController.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using DataPipelineApi.Services;
 
@@ -10,10 +12,10 @@ public class GovernanceController : ControllerBase
   public GovernanceController(IAtlasService atlas) => _atlas = atlas;
 
   [HttpPost("lineage")]
-  public async Task<IActionResult> Lineage([FromBody] object payload)
+  public async Task<IActionResult> Lineage([FromBody] object payload, CancellationToken cancellationToken)
   {
     var json = payload.ToString()!;
-    var res = await _atlas.RegisterLineageAsync(json);
+    var res = await _atlas.RegisterLineageAsync(json, cancellationToken);
     return Ok(new { result = res });
   }
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Controllers/MLController.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Controllers/MLController.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using DataPipelineApi.Services;
 
@@ -10,9 +12,9 @@ public class MLController : ControllerBase
   public MLController(IMLflowService ml) => _ml = ml;
 
   [HttpPost("run")]
-  public async Task<IActionResult> Run([FromQuery]string expId, [FromQuery]string name)
+  public async Task<IActionResult> Run([FromQuery] string expId, [FromQuery] string name, CancellationToken cancellationToken)
   {
-    var res = await _ml.CreateRunAsync(expId, name);
+    var res = await _ml.CreateRunAsync(expId, name, cancellationToken);
     return Ok(new { result = res });
   }
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Controllers/MonitoringController.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Controllers/MonitoringController.cs
@@ -1,5 +1,7 @@
-using Microsoft.AspNetCore.Mvc;
+using System.Threading;
+using System.Threading.Tasks;
 using DataPipelineApi.Services;
+using Microsoft.AspNetCore.Mvc;
 
 namespace DataPipelineApi.Controllers;
 [ApiController]
@@ -10,6 +12,6 @@ public class MonitoringController : ControllerBase
   public MonitoringController(IMonitoringService mon) => _mon = mon;
 
   [HttpGet("health")]
-  public async Task<IActionResult> Health()
-    => Ok(new { status = await _mon.GetHealthAsync() });
+  public async Task<IActionResult> Health(CancellationToken cancellationToken)
+    => Ok(await _mon.GetHealthAsync(cancellationToken));
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Controllers/StreamingController.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Controllers/StreamingController.cs
@@ -1,28 +1,41 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using DataPipelineApi.Models;
 using DataPipelineApi.Services;
 using Microsoft.AspNetCore.Mvc;
-using System.Text.Json;
 
 namespace DataPipelineApi.Controllers;
+
 [ApiController]
 [Route("api/stream")]
 public class StreamingController : ControllerBase
 {
-  private readonly IKafkaService _kaf;
+  private readonly IKafkaService _kafka;
   private readonly IStreamingService _airflow;
+  private readonly ILogger<StreamingController> _logger;
 
-  public StreamingController(IKafkaService kaf, IStreamingService airflow)
-  { _kaf=kaf; _airflow=airflow; }
+  public StreamingController(IKafkaService kafka, IStreamingService airflow, ILogger<StreamingController> logger)
+  {
+    _kafka = kafka;
+    _airflow = airflow;
+    _logger = logger;
+  }
 
   [HttpPost("produce")]
-  public async Task<IActionResult> Produce([FromBody] StreamingRequest req)
+  public async Task<IActionResult> Produce([FromBody] StreamingRequest req, CancellationToken cancellationToken)
   {
-    var msg = JsonSerializer.Serialize(new { ts=DateTime.UtcNow, partition=req.Partition });
-    await _kaf.ProduceAsync(msg);
-    return Ok(new { status="sent" });
+    var msg = JsonSerializer.Serialize(new { ts = DateTime.UtcNow, partition = req.Partition, payload = req.Payload?.RootElement });
+    await _kafka.ProduceAsync(msg, cancellationToken);
+    _logger.LogInformation("Produced message to Kafka partition={Partition}", req.Partition);
+    return Ok(new { status = "sent" });
   }
 
   [HttpPost("run")]
-  public async Task<StreamingResponse> Run()
-    => new() { RunId = await _airflow.TriggerStreamingAsync() };
+  public async Task<ActionResult<StreamingResponse>> Run(CancellationToken cancellationToken)
+  {
+    var id = await _airflow.TriggerStreamingAsync(cancellationToken);
+    _logger.LogInformation("Triggered streaming DAG run {RunId}", id);
+    return Ok(new StreamingResponse { RunId = id, Status = "scheduled" });
+  }
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/HealthChecks/AirflowHealthCheck.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/HealthChecks/AirflowHealthCheck.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using DataPipelineApi.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace DataPipelineApi.HealthChecks;
+
+public class AirflowHealthCheck : IHealthCheck
+{
+  private readonly IHttpClientFactory _clientFactory;
+  private readonly AirflowOptions _options;
+
+  public AirflowHealthCheck(IHttpClientFactory clientFactory, IOptions<AirflowOptions> options)
+  {
+    _clientFactory = clientFactory;
+    _options = options.Value;
+  }
+
+  public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+  {
+    try
+    {
+      var client = _clientFactory.CreateClient("airflow-health");
+      var resp = await client.GetAsync("/health", cancellationToken);
+      if (!resp.IsSuccessStatusCode)
+        return HealthCheckResult.Degraded($"Airflow responded with {resp.StatusCode}");
+
+      var payload = await resp.Content.ReadAsStringAsync(cancellationToken);
+      using var doc = JsonDocument.Parse(payload);
+      var metadatabase = doc.RootElement.GetProperty("metadatabase").GetProperty("status").GetString();
+      var scheduler = doc.RootElement.GetProperty("scheduler").GetProperty("status").GetString();
+      var webserver = doc.RootElement.GetProperty("webserver").GetProperty("status").GetString();
+
+      var allOk = string.Equals(metadatabase, "healthy", StringComparison.OrdinalIgnoreCase)
+                  && string.Equals(scheduler, "healthy", StringComparison.OrdinalIgnoreCase)
+                  && string.Equals(webserver, "healthy", StringComparison.OrdinalIgnoreCase);
+
+      return allOk ? HealthCheckResult.Healthy() : HealthCheckResult.Degraded($"Airflow status: meta={metadatabase}, scheduler={scheduler}, webserver={webserver}");
+    }
+    catch (Exception ex)
+    {
+      return HealthCheckResult.Unhealthy("Airflow health check failed", ex);
+    }
+  }
+}

--- a/sample_dotnet_backend/src/DataPipelineApi/HealthChecks/KafkaHealthCheck.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/HealthChecks/KafkaHealthCheck.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using DataPipelineApi.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace DataPipelineApi.HealthChecks;
+
+public class KafkaHealthCheck : IHealthCheck
+{
+  private readonly KafkaOptions _options;
+
+  public KafkaHealthCheck(IOptions<KafkaOptions> options) => _options = options.Value;
+
+  public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+  {
+    try
+    {
+      var config = new AdminClientConfig
+      {
+        BootstrapServers = _options.BootstrapServers,
+        ClientId = $"{_options.ClientId}-health"
+      };
+      using var admin = new AdminClientBuilder(config).Build();
+      var metadata = admin.GetMetadata(_options.Topic, TimeSpan.FromSeconds(5));
+      var topic = metadata.Topics.FirstOrDefault(t => t.Topic == _options.Topic);
+      if (topic is null || topic.Error.Code != ErrorCode.NoError)
+        return Task.FromResult(HealthCheckResult.Degraded($"Kafka topic '{_options.Topic}' not available: {topic?.Error}"));
+
+      return Task.FromResult(HealthCheckResult.Healthy());
+    }
+    catch (Exception ex)
+    {
+      return Task.FromResult(HealthCheckResult.Unhealthy("Kafka unavailable", ex));
+    }
+  }
+}

--- a/sample_dotnet_backend/src/DataPipelineApi/HealthChecks/MLflowHealthCheck.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/HealthChecks/MLflowHealthCheck.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using DataPipelineApi.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace DataPipelineApi.HealthChecks;
+
+public class MLflowHealthCheck : IHealthCheck
+{
+  private readonly IHttpClientFactory _clientFactory;
+  private readonly MLflowOptions _options;
+
+  public MLflowHealthCheck(IHttpClientFactory clientFactory, IOptions<MLflowOptions> options)
+  {
+    _clientFactory = clientFactory;
+    _options = options.Value;
+  }
+
+  public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+  {
+    try
+    {
+      var client = _clientFactory.CreateClient("mlflow-health");
+      var resp = await client.GetAsync("/api/2.0/mlflow/experiments/list?max_results=1", cancellationToken);
+      if (!resp.IsSuccessStatusCode)
+        return HealthCheckResult.Degraded($"MLflow responded with {resp.StatusCode}");
+
+      return HealthCheckResult.Healthy();
+    }
+    catch (Exception ex)
+    {
+      return HealthCheckResult.Unhealthy("MLflow unreachable", ex);
+    }
+  }
+}

--- a/sample_dotnet_backend/src/DataPipelineApi/HealthChecks/MinioHealthCheck.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/HealthChecks/MinioHealthCheck.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.S3;
+using DataPipelineApi.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace DataPipelineApi.HealthChecks;
+
+public class MinioHealthCheck : IHealthCheck
+{
+  private readonly MinioOptions _options;
+
+  public MinioHealthCheck(IOptions<MinioOptions> options) => _options = options.Value;
+
+  public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+  {
+    try
+    {
+      using var client = new AmazonS3Client(_options.AccessKey, _options.SecretKey,
+        new AmazonS3Config { ServiceURL = $"http://{_options.Endpoint}", ForcePathStyle = true, Timeout = TimeSpan.FromSeconds(15) });
+
+      var buckets = await client.ListBucketsAsync(cancellationToken);
+      var hasBuckets = buckets.Buckets.Any(b => b.BucketName == _options.BucketRaw || b.BucketName == _options.BucketProcessed);
+      return hasBuckets ? HealthCheckResult.Healthy() : HealthCheckResult.Degraded("MinIO reachable but buckets missing");
+    }
+    catch (Exception ex)
+    {
+      return HealthCheckResult.Unhealthy("MinIO unreachable", ex);
+    }
+  }
+}

--- a/sample_dotnet_backend/src/DataPipelineApi/HealthChecks/MySqlHealthCheck.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/HealthChecks/MySqlHealthCheck.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DataPipelineApi.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using MySqlConnector;
+
+namespace DataPipelineApi.HealthChecks;
+
+public class MySqlHealthCheck : IHealthCheck
+{
+  private readonly DatabaseOptions _options;
+
+  public MySqlHealthCheck(IOptions<DatabaseOptions> options) => _options = options.Value;
+
+  public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+  {
+    try
+    {
+      await using var conn = new MySqlConnection(_options.MySql);
+      await conn.OpenAsync(cancellationToken);
+      return HealthCheckResult.Healthy();
+    }
+    catch (Exception ex)
+    {
+      return HealthCheckResult.Unhealthy("MySQL connection failed", ex);
+    }
+  }
+}

--- a/sample_dotnet_backend/src/DataPipelineApi/HealthChecks/PostgresHealthCheck.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/HealthChecks/PostgresHealthCheck.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DataPipelineApi.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Npgsql;
+
+namespace DataPipelineApi.HealthChecks;
+
+public class PostgresHealthCheck : IHealthCheck
+{
+  private readonly DatabaseOptions _options;
+
+  public PostgresHealthCheck(IOptions<DatabaseOptions> options) => _options = options.Value;
+
+  public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+  {
+    try
+    {
+      await using var conn = new NpgsqlConnection(_options.Postgres);
+      await conn.OpenAsync(cancellationToken);
+      return HealthCheckResult.Healthy();
+    }
+    catch (Exception ex)
+    {
+      return HealthCheckResult.Unhealthy("PostgreSQL connection failed", ex);
+    }
+  }
+}

--- a/sample_dotnet_backend/src/DataPipelineApi/Models/BatchRequest.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Models/BatchRequest.cs
@@ -1,3 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace DataPipelineApi.Models;
-public class BatchRequest { public string SourceTable { get; set; } = ""; }
-public class BatchResponse { public string RunId { get; set; } = ""; public string GEReport { get; set; } = ""; }
+
+public class BatchRequest
+{
+  [Required, RegularExpression("^[A-Za-z0-9_]+$")]
+  public string SourceTable { get; set; } = string.Empty;
+
+  [StringLength(200)]
+  public string? DestinationPrefix { get; set; }
+
+  [Range(1, 100000)]
+  public int? Limit { get; set; }
+
+  public bool TriggerAirflow { get; set; } = true;
+
+  public bool RunGreatExpectations { get; set; } = true;
+}
+
+public class BatchResponse
+{
+  public string ObjectKey { get; set; } = string.Empty;
+  public string? RunId { get; set; }
+  public string? GEReport { get; set; }
+}

--- a/sample_dotnet_backend/src/DataPipelineApi/Models/StreamingRequest.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Models/StreamingRequest.cs
@@ -1,3 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+
 namespace DataPipelineApi.Models;
-public class StreamingRequest { public int Partition { get; set; } = 0; }
-public class StreamingResponse { public string RunId { get; set; } = ""; }
+
+public class StreamingRequest
+{
+  [Range(0, int.MaxValue)]
+  public int Partition { get; set; } = 0;
+
+  public JsonDocument? Payload { get; set; }
+}
+
+public class StreamingResponse
+{
+  public string RunId { get; set; } = string.Empty;
+  public string? Status { get; set; }
+}

--- a/sample_dotnet_backend/src/DataPipelineApi/Options/AirflowOptions.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Options/AirflowOptions.cs
@@ -1,1 +1,24 @@
-namespace DataPipelineApi.Options; public class AirflowOptions { public string BaseUrl { get; set; } = ""; public string Username { get; set; } = ""; public string Password { get; set; } = ""; }
+using System.ComponentModel.DataAnnotations;
+
+namespace DataPipelineApi.Options;
+
+public class AirflowOptions
+{
+  [Required, MinLength(1)]
+  public string BaseUrl { get; init; } = string.Empty;
+
+  [Required, MinLength(1)]
+  public string Username { get; init; } = string.Empty;
+
+  [Required, MinLength(1)]
+  public string Password { get; init; } = string.Empty;
+
+  [Required, MinLength(1)]
+  public string BatchDagId { get; init; } = "batch_ingestion_dag";
+
+  [Required, MinLength(1)]
+  public string StreamingDagId { get; init; } = "streaming_monitoring_dag";
+
+  [Range(5, 300)]
+  public int RequestTimeoutSeconds { get; init; } = 30;
+}

--- a/sample_dotnet_backend/src/DataPipelineApi/Options/AtlasOptions.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Options/AtlasOptions.cs
@@ -1,1 +1,15 @@
-namespace DataPipelineApi.Options; public class AtlasOptions { public string Endpoint { get; set; } = ""; public string Username { get; set; } = ""; public string Password { get; set; } = ""; }
+using System.ComponentModel.DataAnnotations;
+
+namespace DataPipelineApi.Options;
+
+public class AtlasOptions
+{
+  [Required, MinLength(3)]
+  public string Endpoint { get; init; } = string.Empty;
+
+  [Required, MinLength(1)]
+  public string Username { get; init; } = string.Empty;
+
+  [Required, MinLength(1)]
+  public string Password { get; init; } = string.Empty;
+}

--- a/sample_dotnet_backend/src/DataPipelineApi/Options/DatabaseOptions.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Options/DatabaseOptions.cs
@@ -1,1 +1,15 @@
-namespace DataPipelineApi.Options; public class DatabaseOptions { public string MySql { get; set; } = ""; public string Postgres { get; set; } = ""; }
+using System.ComponentModel.DataAnnotations;
+
+namespace DataPipelineApi.Options;
+
+public class DatabaseOptions
+{
+  [Required, MinLength(1)]
+  public string MySql { get; init; } = string.Empty;
+
+  [Required, MinLength(1)]
+  public string Postgres { get; init; } = string.Empty;
+
+  [Range(5, 300)]
+  public int CommandTimeoutSeconds { get; init; } = 30;
+}

--- a/sample_dotnet_backend/src/DataPipelineApi/Options/GEOptions.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Options/GEOptions.cs
@@ -1,1 +1,12 @@
-namespace DataPipelineApi.Options; public class GEOptions { public string CliPath { get; set; } = ""; }
+using System.ComponentModel.DataAnnotations;
+
+namespace DataPipelineApi.Options;
+
+public class GEOptions
+{
+  [Required, MinLength(1)]
+  public string CliPath { get; init; } = string.Empty;
+
+  [Range(5, 1800)]
+  public int TimeoutSeconds { get; init; } = 300;
+}

--- a/sample_dotnet_backend/src/DataPipelineApi/Options/GitHubOptions.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Options/GitHubOptions.cs
@@ -1,1 +1,15 @@
-namespace DataPipelineApi.Options; public class GitHubOptions { public string ActionsApi { get; set; } = ""; public string Token { get; set; } = ""; }
+using System.ComponentModel.DataAnnotations;
+
+namespace DataPipelineApi.Options;
+
+public class GitHubOptions
+{
+  [Required, MinLength(3)]
+  public string ActionsApi { get; init; } = string.Empty;
+
+  [Required, MinLength(10)]
+  public string Token { get; init; } = string.Empty;
+
+  [Required, MinLength(1)]
+  public string UserAgent { get; init; } = "data-pipeline-api";
+}

--- a/sample_dotnet_backend/src/DataPipelineApi/Options/KafkaOptions.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Options/KafkaOptions.cs
@@ -1,1 +1,21 @@
-namespace DataPipelineApi.Options; public class KafkaOptions { public string BootstrapServers { get; set; } = ""; public string Topic { get; set; } = ""; }
+using System.ComponentModel.DataAnnotations;
+
+namespace DataPipelineApi.Options;
+
+public class KafkaOptions
+{
+  [Required, MinLength(3)]
+  public string BootstrapServers { get; init; } = string.Empty;
+
+  [Required, MinLength(1)]
+  public string Topic { get; init; } = string.Empty;
+
+  [MinLength(1)]
+  public string ClientId { get; init; } = "data-pipeline-api";
+
+  [Range(500, 30000)]
+  public int MessageTimeoutMs { get; init; } = 5000;
+
+  [Range(1, 10)]
+  public int ProducerFlushSeconds { get; init; } = 2;
+}

--- a/sample_dotnet_backend/src/DataPipelineApi/Options/MLflowOptions.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Options/MLflowOptions.cs
@@ -1,1 +1,12 @@
-namespace DataPipelineApi.Options; public class MLflowOptions { public string TrackingUri { get; set; } = ""; }
+using System.ComponentModel.DataAnnotations;
+
+namespace DataPipelineApi.Options;
+
+public class MLflowOptions
+{
+  [Required, MinLength(3)]
+  public string TrackingUri { get; init; } = string.Empty;
+
+  [Range(5, 300)]
+  public int RequestTimeoutSeconds { get; init; } = 30;
+}

--- a/sample_dotnet_backend/src/DataPipelineApi/Options/MinioOptions.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Options/MinioOptions.cs
@@ -1,1 +1,24 @@
-namespace DataPipelineApi.Options; public class MinioOptions { public string Endpoint { get; set; } = ""; public string AccessKey { get; set; } = ""; public string SecretKey { get; set; } = ""; public string BucketRaw { get; set; } = ""; public string BucketProcessed { get; set; } = ""; }
+using System.ComponentModel.DataAnnotations;
+
+namespace DataPipelineApi.Options;
+
+public class MinioOptions
+{
+  [Required, MinLength(3)]
+  public string Endpoint { get; init; } = string.Empty;
+
+  [Required, MinLength(1)]
+  public string AccessKey { get; init; } = string.Empty;
+
+  [Required, MinLength(1)]
+  public string SecretKey { get; init; } = string.Empty;
+
+  [Required, MinLength(1)]
+  public string BucketRaw { get; init; } = string.Empty;
+
+  [Required, MinLength(1)]
+  public string BucketProcessed { get; init; } = string.Empty;
+
+  [Range(1, 4)]
+  public int MaxUploadRetries { get; init; } = 2;
+}

--- a/sample_dotnet_backend/src/DataPipelineApi/Program.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Program.cs
@@ -1,40 +1,117 @@
+using System.Linq;
+using System.Text.Json;
+using DataPipelineApi.HealthChecks;
 using DataPipelineApi.Options;
 using DataPipelineApi.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.HttpLogging;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Polly;
 using Polly.Extensions.Http;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// configure
-builder.Services.Configure<DatabaseOptions>(builder.Configuration.GetSection("ConnectionStrings"));
-builder.Services.Configure<MinioOptions>(builder.Configuration.GetSection("Minio"));
-builder.Services.Configure<KafkaOptions>(builder.Configuration.GetSection("Kafka"));
-builder.Services.Configure<AirflowOptions>(builder.Configuration.GetSection("Airflow"));
-builder.Services.Configure<GEOptions>(builder.Configuration.GetSection("GreatExpectations"));
-builder.Services.Configure<AtlasOptions>(builder.Configuration.GetSection("Atlas"));
-builder.Services.Configure<MLflowOptions>(builder.Configuration.GetSection("MLflow"));
-builder.Services.Configure<GitHubOptions>(builder.Configuration.GetSection("GitHub"));
+builder.Services.AddOptions<DatabaseOptions>().Bind(builder.Configuration.GetSection("ConnectionStrings")).ValidateDataAnnotations().ValidateOnStart();
+builder.Services.AddOptions<MinioOptions>().Bind(builder.Configuration.GetSection("Minio")).ValidateDataAnnotations().ValidateOnStart();
+builder.Services.AddOptions<KafkaOptions>().Bind(builder.Configuration.GetSection("Kafka")).ValidateDataAnnotations().ValidateOnStart();
+builder.Services.AddOptions<AirflowOptions>().Bind(builder.Configuration.GetSection("Airflow")).ValidateDataAnnotations().ValidateOnStart();
+builder.Services.AddOptions<GEOptions>().Bind(builder.Configuration.GetSection("GreatExpectations")).ValidateDataAnnotations().ValidateOnStart();
+builder.Services.AddOptions<AtlasOptions>().Bind(builder.Configuration.GetSection("Atlas")).ValidateDataAnnotations().ValidateOnStart();
+builder.Services.AddOptions<MLflowOptions>().Bind(builder.Configuration.GetSection("MLflow")).ValidateDataAnnotations().ValidateOnStart();
+builder.Services.AddOptions<GitHubOptions>().Bind(builder.Configuration.GetSection("GitHub")).ValidateDataAnnotations().ValidateOnStart();
 
-// http clients with retry
-builder.Services.AddHttpClient<IBatchService, BatchService>()
-  .AddPolicyHandler(HttpPolicyExtensions.HandleTransientHttpError()
-    .WaitAndRetryAsync(3, retry => TimeSpan.FromSeconds(Math.Pow(2, retry))));
-builder.Services.AddHttpClient<IStreamingService, StreamingService>()
-  .AddPolicyHandler(HttpPolicyExtensions.HandleTransientHttpError()
-    .WaitAndRetryAsync(3, retry => TimeSpan.FromSeconds(Math.Pow(2, retry))));
-builder.Services.AddHttpClient<IAtlasService, AtlasService>();
-builder.Services.AddHttpClient<IMLflowService, MLflowService>();
-builder.Services.AddHttpClient<ICIService, CIService>();
+var retryPolicy = HttpPolicyExtensions.HandleTransientHttpError()
+  .WaitAndRetryAsync(3, retry => TimeSpan.FromSeconds(Math.Pow(2, retry)));
 
-// core services
+builder.Services.AddHttpClient<IBatchService, BatchService>((sp, http) =>
+{
+  var opt = sp.GetRequiredService<IOptions<AirflowOptions>>().Value;
+  http.BaseAddress = new Uri(opt.BaseUrl);
+  http.Timeout = TimeSpan.FromSeconds(opt.RequestTimeoutSeconds);
+  http.DefaultRequestHeaders.UserAgent.ParseAdd("DataPipelineApi/1.0");
+}).AddPolicyHandler(retryPolicy);
+
+builder.Services.AddHttpClient<IStreamingService, StreamingService>((sp, http) =>
+{
+  var opt = sp.GetRequiredService<IOptions<AirflowOptions>>().Value;
+  http.BaseAddress = new Uri(opt.BaseUrl);
+  http.Timeout = TimeSpan.FromSeconds(opt.RequestTimeoutSeconds);
+  http.DefaultRequestHeaders.UserAgent.ParseAdd("DataPipelineApi/1.0");
+}).AddPolicyHandler(retryPolicy);
+
+builder.Services.AddHttpClient<IAtlasService, AtlasService>((sp, http) =>
+{
+  var opt = sp.GetRequiredService<IOptions<AtlasOptions>>().Value;
+  http.BaseAddress = new Uri(opt.Endpoint);
+  http.Timeout = TimeSpan.FromSeconds(30);
+});
+builder.Services.AddHttpClient<IMLflowService, MLflowService>((sp, http) =>
+{
+  var opt = sp.GetRequiredService<IOptions<MLflowOptions>>().Value;
+  http.BaseAddress = new Uri(opt.TrackingUri);
+  http.Timeout = TimeSpan.FromSeconds(opt.RequestTimeoutSeconds);
+}).AddPolicyHandler(retryPolicy);
+builder.Services.AddHttpClient<ICIService, CIService>((sp, http) =>
+{
+  var opt = sp.GetRequiredService<IOptions<GitHubOptions>>().Value;
+  http.Timeout = TimeSpan.FromSeconds(30);
+  http.DefaultRequestHeaders.UserAgent.ParseAdd(opt.UserAgent);
+});
+
+builder.Services.AddHttpClient("airflow-health", (sp, http) =>
+{
+  var opt = sp.GetRequiredService<IOptions<AirflowOptions>>().Value;
+  http.BaseAddress = new Uri(opt.BaseUrl);
+  http.Timeout = TimeSpan.FromSeconds(opt.RequestTimeoutSeconds);
+  var tok = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"{opt.Username}:{opt.Password}"));
+  http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", tok);
+});
+builder.Services.AddHttpClient("mlflow-health", (sp, http) =>
+{
+  var opt = sp.GetRequiredService<IOptions<MLflowOptions>>().Value;
+  http.BaseAddress = new Uri(opt.TrackingUri);
+  http.Timeout = TimeSpan.FromSeconds(opt.RequestTimeoutSeconds);
+});
+
 builder.Services.AddSingleton<IDbService, DbService>();
 builder.Services.AddSingleton<IStorageService, MinioService>();
 builder.Services.AddSingleton<IKafkaService, KafkaService>();
 builder.Services.AddSingleton<IGEValidationService, GEValidationService>();
 builder.Services.AddSingleton<IMonitoringService, MonitoringService>();
 
-builder.Services.AddControllers().AddNewtonsoftJson();
+builder.Services.AddHealthChecks()
+  .AddCheck<MySqlHealthCheck>("mysql")
+  .AddCheck<PostgresHealthCheck>("postgres")
+  .AddCheck<MinioHealthCheck>("minio")
+  .AddCheck<KafkaHealthCheck>("kafka")
+  .AddCheck<AirflowHealthCheck>("airflow")
+  .AddCheck<MLflowHealthCheck>("mlflow");
+
+builder.Services.AddHttpLogging(logging =>
+{
+  logging.LoggingFields = HttpLoggingFields.RequestMethod | HttpLoggingFields.RequestPath | HttpLoggingFields.ResponseStatusCode;
+});
+
+builder.Services.AddResponseCompression();
+
+builder.Services.AddControllers().AddNewtonsoftJson()
+  .ConfigureApiBehaviorOptions(options =>
+  {
+    options.InvalidModelStateResponseFactory = context =>
+    {
+      var details = new ValidationProblemDetails(context.ModelState)
+      {
+        Status = StatusCodes.Status400BadRequest,
+        Title = "Invalid request payload"
+      };
+      return new BadRequestObjectResult(details);
+    };
+  });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
@@ -42,12 +119,75 @@ builder.Services.AddSwaggerGen(c =>
 });
 
 var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+  app.UseHsts();
+}
+
+app.UseForwardedHeaders(new ForwardedHeadersOptions
+{
+  ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+});
+
+app.UseExceptionHandler(errorApp =>
+{
+  errorApp.Run(async context =>
+  {
+    var problem = new ProblemDetails
+    {
+      Status = StatusCodes.Status500InternalServerError,
+      Title = "Unexpected error",
+      Detail = "An unexpected error occurred while processing the request",
+      Instance = context.Request.Path
+    };
+    problem.Extensions["traceId"] = context.TraceIdentifier;
+    context.Response.StatusCode = problem.Status.Value;
+    context.Response.ContentType = "application/problem+json";
+    await context.Response.WriteAsJsonAsync(problem);
+  });
+});
+
 if (app.Environment.IsDevelopment())
 {
   app.UseDeveloperExceptionPage();
   app.UseSwagger();
   app.UseSwaggerUI();
 }
+
 app.UseHttpsRedirection();
+app.UseHttpLogging();
+app.UseResponseCompression();
+
+app.Use(async (context, next) =>
+{
+  var requestId = context.Request.Headers["X-Request-ID"].FirstOrDefault() ?? Guid.NewGuid().ToString();
+  context.Response.Headers["X-Request-ID"] = requestId;
+  using (app.Logger.BeginScope(new Dictionary<string, object> { { "RequestId", requestId }, { "TraceId", context.TraceIdentifier } }))
+  {
+    await next();
+  }
+});
+app.UseRouting();
+
 app.MapControllers();
+app.MapHealthChecks("/health", new HealthCheckOptions
+{
+  ResponseWriter = async (ctx, report) =>
+  {
+    ctx.Response.ContentType = "application/json";
+    var payload = new
+    {
+      status = report.Status.ToString(),
+      results = report.Entries.Select(e => new
+      {
+        key = e.Key,
+        status = e.Value.Status.ToString(),
+        description = e.Value.Description
+      })
+    };
+    await ctx.Response.WriteAsync(JsonSerializer.Serialize(payload));
+  }
+});
+
 app.Run();

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/AtlasService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/AtlasService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using DataPipelineApi.Options;
@@ -11,21 +12,25 @@ namespace DataPipelineApi.Services
     public class AtlasService : IAtlasService
     {
         private readonly HttpClient _http;
+        private readonly AtlasOptions _options;
 
         public AtlasService(HttpClient http, IOptions<AtlasOptions> opt)
         {
             _http = http;
-            _http.BaseAddress = new Uri(opt.Value.Endpoint);
-            var token = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{opt.Value.Username}:{opt.Value.Password}"));
+            _options = opt.Value;
+            if (_http.BaseAddress is null)
+                _http.BaseAddress = new Uri(_options.Endpoint);
+
+            var token = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_options.Username}:{_options.Password}"));
             _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", token);
         }
 
-        public async Task<string> RegisterLineageAsync(string payload)
+        public async Task<string> RegisterLineageAsync(string payload, CancellationToken cancellationToken)
         {
             var content = new StringContent(payload, Encoding.UTF8, "application/json");
-            var resp = await _http.PostAsync("/lineage", content);
+            var resp = await _http.PostAsync("/lineage", content, cancellationToken);
             resp.EnsureSuccessStatusCode();
-            return await resp.Content.ReadAsStringAsync();
+            return await resp.Content.ReadAsStringAsync(cancellationToken);
         }
     }
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/BatchService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/BatchService.cs
@@ -1,5 +1,10 @@
+using System;
+using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using DataPipelineApi.Options;
 
@@ -7,23 +12,28 @@ namespace DataPipelineApi.Services;
 public class BatchService : IBatchService
 {
   private readonly HttpClient _http;
+  private readonly AirflowOptions _options;
   public BatchService(HttpClient http, IOptions<AirflowOptions> opt)
   {
     _http = http;
-    var v = opt.Value;
-    _http.BaseAddress = new Uri(v.BaseUrl);
-    var tok = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{v.Username}:{v.Password}"));
+    _options = opt.Value;
+    if (_http.BaseAddress is null)
+      _http.BaseAddress = new Uri(_options.BaseUrl);
+
+    var tok = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_options.Username}:{_options.Password}"));
     _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", tok);
   }
-  public async Task<string> TriggerBatchAsync()
+  public async Task<string> TriggerBatchAsync(CancellationToken cancellationToken)
   {
     var id = $"batch_{DateTime.UtcNow:yyyyMMddHHmmss}";
-    await _http.PostAsJsonAsync("/dags/batch_ingestion_dag/dagRuns", new { dag_run_id = id });
+    var resp = await _http.PostAsJsonAsync($"/dags/{_options.BatchDagId}/dagRuns", new { dag_run_id = id }, cancellationToken);
+    resp.EnsureSuccessStatusCode();
     return id;
   }
-  public async Task<string> GetBatchStatusAsync(string runId)
+  public async Task<string> GetBatchStatusAsync(string runId, CancellationToken cancellationToken)
   {
-    var r = await _http.GetAsync($"/dags/batch_ingestion_dag/dagRuns/{runId}");
-    return await r.Content.ReadAsStringAsync();
+    var r = await _http.GetAsync($"/dags/{_options.BatchDagId}/dagRuns/{runId}", cancellationToken);
+    r.EnsureSuccessStatusCode();
+    return await r.Content.ReadAsStringAsync(cancellationToken);
   }
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/CIService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/CIService.cs
@@ -1,4 +1,9 @@
+using System;
+using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using DataPipelineApi.Options;
 
@@ -6,18 +11,26 @@ namespace DataPipelineApi.Services;
 public class CIService : ICIService
 {
   private readonly HttpClient _http;
-  private readonly string _api;
+  private readonly GitHubOptions _options;
   public CIService(HttpClient http, IOptions<GitHubOptions> opt)
   {
     _http = http;
-    _api = opt.Value.ActionsApi;
+    _options = opt.Value;
+    if (_http.BaseAddress is null)
+    {
+      var baseUri = _options.ActionsApi.EndsWith("/") ? _options.ActionsApi : $"{_options.ActionsApi}/";
+      _http.BaseAddress = new Uri(baseUri);
+    }
+
     _http.DefaultRequestHeaders.Authorization =
-      new AuthenticationHeaderValue("Bearer", opt.Value.Token);
+      new AuthenticationHeaderValue("Bearer", _options.Token);
+    _http.DefaultRequestHeaders.UserAgent.ParseAdd(_options.UserAgent);
   }
-  public async Task<string> TriggerWorkflowAsync(string wf, string branch)
+  public async Task<string> TriggerWorkflowAsync(string wf, string branch, CancellationToken cancellationToken)
   {
     var payload = new { @ref = branch };
-    var r = await _http.PostAsJsonAsync($"{_api}/{wf}/dispatches", payload);
-    return await r.Content.ReadAsStringAsync();
+    var r = await _http.PostAsJsonAsync($"{wf}/dispatches", payload, cancellationToken);
+    r.EnsureSuccessStatusCode();
+    return await r.Content.ReadAsStringAsync(cancellationToken);
   }
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/GEValidationService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/GEValidationService.cs
@@ -1,4 +1,8 @@
+using System;
 using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using DataPipelineApi.Options;
 
@@ -6,12 +10,38 @@ namespace DataPipelineApi.Services;
 public class GEValidationService : IGEValidationService
 {
   private readonly string _cli;
-  public GEValidationService(IOptions<GEOptions> opt) => _cli = opt.Value.CliPath;
-  public Task<string> ValidateAsync(string suite)
+  private readonly int _timeoutSeconds;
+
+  public GEValidationService(IOptions<GEOptions> opt)
   {
-    var p = Process.Start(new ProcessStartInfo(_cli, $"checkpoint run {suite}") { RedirectStandardOutput = true })!;
-    var outp = p.StandardOutput.ReadToEnd();
-    p.WaitForExit();
-    return Task.FromResult(outp);
+    var cfg = opt.Value;
+    _cli = cfg.CliPath;
+    _timeoutSeconds = cfg.TimeoutSeconds;
+  }
+
+  public async Task<string> ValidateAsync(string suite, CancellationToken cancellationToken)
+  {
+    if (!File.Exists(_cli))
+      throw new FileNotFoundException($"Great Expectations CLI not found at {_cli}");
+
+    using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+    cts.CancelAfter(TimeSpan.FromSeconds(_timeoutSeconds));
+
+    var psi = new ProcessStartInfo(_cli, $"checkpoint run {suite}")
+    {
+      RedirectStandardError = true,
+      RedirectStandardOutput = true,
+      UseShellExecute = false
+    };
+
+    using var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start Great Expectations CLI");
+    var stdoutTask = process.StandardOutput.ReadToEndAsync();
+    var stderrTask = process.StandardError.ReadToEndAsync();
+
+    await Task.WhenAll(process.WaitForExitAsync(cts.Token), stdoutTask, stderrTask);
+    if (process.ExitCode != 0)
+      throw new InvalidOperationException($"Great Expectations validation failed: {await stderrTask}");
+
+    return await stdoutTask;
   }
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/IAtlasService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/IAtlasService.cs
@@ -1,7 +1,9 @@
-namespace DataPipelineApi.Services
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DataPipelineApi.Services;
+
+public interface IAtlasService
 {
-    public interface IAtlasService
-    {
-        Task<string> RegisterLineageAsync(string payload);
-    }
+  Task<string> RegisterLineageAsync(string payload, CancellationToken cancellationToken);
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/IBatchService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/IBatchService.cs
@@ -1,6 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace DataPipelineApi.Services;
+
 public interface IBatchService
 {
-  Task<string> TriggerBatchAsync();
-  Task<string> GetBatchStatusAsync(string runId);
+  Task<string> TriggerBatchAsync(CancellationToken cancellationToken);
+  Task<string> GetBatchStatusAsync(string runId, CancellationToken cancellationToken);
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/ICIService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/ICIService.cs
@@ -1,5 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace DataPipelineApi.Services;
+
 public interface ICIService
 {
-  Task<string> TriggerWorkflowAsync(string workflowFile, string branch);
+  Task<string> TriggerWorkflowAsync(string workflowFile, string branch, CancellationToken cancellationToken);
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/IDbService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/IDbService.cs
@@ -1,7 +1,12 @@
 using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace DataPipelineApi.Services;
+
 public interface IDbService
 {
-  Task<IEnumerable<dynamic>> QueryMySqlAsync(string sql);
-  Task ExecutePostgresAsync(string sql);
+  Task<IReadOnlyList<IDictionary<string, object?>>> ReadMySqlTableAsync(string table, int? limit, CancellationToken cancellationToken);
+  Task ExecutePostgresAsync(string sql, CancellationToken cancellationToken);
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/IGEValidationService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/IGEValidationService.cs
@@ -1,5 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace DataPipelineApi.Services;
+
 public interface IGEValidationService
 {
-  Task<string> ValidateAsync(string suite);
+  Task<string> ValidateAsync(string suite, CancellationToken cancellationToken);
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/IKafkaService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/IKafkaService.cs
@@ -1,5 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace DataPipelineApi.Services;
+
 public interface IKafkaService
 {
-  Task ProduceAsync(string message);
+  Task ProduceAsync(string message, CancellationToken cancellationToken);
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/IMLflowService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/IMLflowService.cs
@@ -1,5 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace DataPipelineApi.Services;
+
 public interface IMLflowService
 {
-  Task<string> CreateRunAsync(string experimentId, string runName);
+  Task<string> CreateRunAsync(string experimentId, string runName, CancellationToken cancellationToken);
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/IMonitoringService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/IMonitoringService.cs
@@ -1,5 +1,10 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace DataPipelineApi.Services;
+
 public interface IMonitoringService
 {
-  Task<string> GetHealthAsync();
+  Task<IDictionary<string, string>> GetHealthAsync(CancellationToken cancellationToken);
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/IStorageService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/IStorageService.cs
@@ -1,8 +1,12 @@
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace DataPipelineApi.Services;
+
 public interface IStorageService
 {
-  Task UploadRawAsync(string key, Stream data);
-  Task<Stream> DownloadRawAsync(string key);
-  Task UploadProcessedAsync(string key, Stream data);
+  Task UploadRawAsync(string key, Stream data, CancellationToken cancellationToken);
+  Task<Stream> DownloadRawAsync(string key, CancellationToken cancellationToken);
+  Task UploadProcessedAsync(string key, Stream data, CancellationToken cancellationToken);
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/IStreamingService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/IStreamingService.cs
@@ -1,6 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace DataPipelineApi.Services;
+
 public interface IStreamingService
 {
-  Task<string> TriggerStreamingAsync();
-  Task<string> GetStreamingStatusAsync(string runId);
+  Task<string> TriggerStreamingAsync(CancellationToken cancellationToken);
+  Task<string> GetStreamingStatusAsync(string runId, CancellationToken cancellationToken);
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/KafkaService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/KafkaService.cs
@@ -1,18 +1,39 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 using Microsoft.Extensions.Options;
 using DataPipelineApi.Options;
 
 namespace DataPipelineApi.Services;
-public class KafkaService : IKafkaService
+public class KafkaService : IKafkaService, IAsyncDisposable
 {
-  private readonly IProducer<Null,string> _p;
+  private readonly IProducer<Null, string> _producer;
   private readonly string _topic;
+  private readonly KafkaOptions _options;
   public KafkaService(IOptions<KafkaOptions> opt)
   {
-    var v = opt.Value;
-    _topic = v.Topic;
-    _p = new ProducerBuilder<Null,string>(new ProducerConfig { BootstrapServers = v.BootstrapServers }).Build();
+    _options = opt.Value;
+    _topic = _options.Topic;
+    var cfg = new ProducerConfig
+    {
+      BootstrapServers = _options.BootstrapServers,
+      ClientId = _options.ClientId,
+      Acks = Acks.All,
+      EnableIdempotence = true,
+      MessageSendMaxRetries = 3,
+      MessageTimeoutMs = _options.MessageTimeoutMs
+    };
+    _producer = new ProducerBuilder<Null, string>(cfg).Build();
   }
-  public async Task ProduceAsync(string message)
-    => await _p.ProduceAsync(_topic, new Message<Null,string> { Value = message });
+
+  public async Task ProduceAsync(string message, CancellationToken cancellationToken)
+    => await _producer.ProduceAsync(_topic, new Message<Null, string> { Value = message }, cancellationToken);
+
+  public async ValueTask DisposeAsync()
+  {
+    _producer.Flush(TimeSpan.FromSeconds(_options.ProducerFlushSeconds));
+    _producer.Dispose();
+    await Task.CompletedTask;
+  }
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/MLflowService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/MLflowService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
@@ -11,14 +12,17 @@ namespace DataPipelineApi.Services
     public class MLflowService : IMLflowService
     {
         private readonly HttpClient _http;
+        private readonly MLflowOptions _options;
 
         public MLflowService(HttpClient http, IOptions<MLflowOptions> opt)
         {
             _http = http;
-            _http.BaseAddress = new Uri(opt.Value.TrackingUri);
+            _options = opt.Value;
+            if (_http.BaseAddress is null)
+                _http.BaseAddress = new Uri(_options.TrackingUri);
         }
 
-        public async Task<string> CreateRunAsync(string experimentId, string runName)
+        public async Task<string> CreateRunAsync(string experimentId, string runName, CancellationToken cancellationToken)
         {
             var obj = new JObject
             {
@@ -26,9 +30,9 @@ namespace DataPipelineApi.Services
                 ["run_name"] = runName
             };
             var content = new StringContent(obj.ToString(), Encoding.UTF8, "application/json");
-            var resp = await _http.PostAsync("/api/2.0/mlflow/runs/create", content);
+            var resp = await _http.PostAsync("/api/2.0/mlflow/runs/create", content, cancellationToken);
             resp.EnsureSuccessStatusCode();
-            return await resp.Content.ReadAsStringAsync();
+            return await resp.Content.ReadAsStringAsync(cancellationToken);
         }
     }
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/MinioService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/MinioService.cs
@@ -1,7 +1,11 @@
+using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Amazon;
 using Amazon.S3;
 using Amazon.S3.Model;
+using Amazon.S3.Util;
 using Microsoft.Extensions.Options;
 using DataPipelineApi.Options;
 
@@ -10,21 +14,80 @@ public class MinioService : IStorageService
 {
   private readonly AmazonS3Client _s3;
   private readonly string _bRaw, _bProc;
+  private readonly MinioOptions _options;
+  private readonly SemaphoreSlim _bucketGate = new(1, 1);
+  private bool _bucketsEnsured;
   public MinioService(IOptions<MinioOptions> opt)
   {
-    var v = opt.Value;
-    _s3 = new AmazonS3Client(v.AccessKey, v.SecretKey,
-      new AmazonS3Config { ServiceURL = $"http://{v.Endpoint}", ForcePathStyle = true });
-    _bRaw = v.BucketRaw; _bProc = v.BucketProcessed;
+    _options = opt.Value;
+    _s3 = new AmazonS3Client(_options.AccessKey, _options.SecretKey,
+      new AmazonS3Config { ServiceURL = $"http://{_options.Endpoint}", ForcePathStyle = true, Timeout = TimeSpan.FromSeconds(30) });
+    _bRaw = _options.BucketRaw;
+    _bProc = _options.BucketProcessed;
   }
-  public async Task UploadRawAsync(string key, Stream data)
-    => await _s3.PutObjectAsync(new PutObjectRequest { BucketName = _bRaw, Key = key, InputStream = data });
-  public async Task<Stream> DownloadRawAsync(string key)
+
+  public async Task UploadRawAsync(string key, Stream data, CancellationToken cancellationToken)
   {
-    var r = await _s3.GetObjectAsync(_bRaw, key);
-    var ms = new MemoryStream(); await r.ResponseStream.CopyToAsync(ms); ms.Position = 0;
+    await EnsureBucketsAsync(cancellationToken);
+    await PutWithRetryAsync(new PutObjectRequest { BucketName = _bRaw, Key = key, InputStream = data }, cancellationToken);
+  }
+
+  public async Task<Stream> DownloadRawAsync(string key, CancellationToken cancellationToken)
+  {
+    await EnsureBucketsAsync(cancellationToken);
+    var r = await _s3.GetObjectAsync(_bRaw, key, cancellationToken);
+    var ms = new MemoryStream();
+    await r.ResponseStream.CopyToAsync(ms, cancellationToken);
+    ms.Position = 0;
     return ms;
   }
-  public async Task UploadProcessedAsync(string key, Stream data)
-    => await _s3.PutObjectAsync(new PutObjectRequest { BucketName = _bProc, Key = key, InputStream = data });
+
+  public async Task UploadProcessedAsync(string key, Stream data, CancellationToken cancellationToken)
+  {
+    await EnsureBucketsAsync(cancellationToken);
+    await PutWithRetryAsync(new PutObjectRequest { BucketName = _bProc, Key = key, InputStream = data }, cancellationToken);
+  }
+
+  private async Task EnsureBucketsAsync(CancellationToken cancellationToken)
+  {
+    if (_bucketsEnsured) return;
+
+    await _bucketGate.WaitAsync(cancellationToken);
+    try
+    {
+      if (_bucketsEnsured) return;
+      await EnsureBucketAsync(_bRaw, cancellationToken);
+      await EnsureBucketAsync(_bProc, cancellationToken);
+      _bucketsEnsured = true;
+    }
+    finally
+    {
+      _bucketGate.Release();
+    }
+  }
+
+  private async Task EnsureBucketAsync(string bucketName, CancellationToken cancellationToken)
+  {
+    var exists = await AmazonS3Util.DoesS3BucketExistV2Async(_s3, bucketName);
+    if (!exists)
+      await _s3.PutBucketAsync(new PutBucketRequest { BucketName = bucketName }, cancellationToken);
+  }
+
+  private async Task PutWithRetryAsync(PutObjectRequest request, CancellationToken cancellationToken)
+  {
+    var attempts = 0;
+    while (true)
+    {
+      attempts++;
+      try
+      {
+        await _s3.PutObjectAsync(request, cancellationToken);
+        return;
+      }
+      catch when (attempts <= _options.MaxUploadRetries)
+      {
+        await Task.Delay(TimeSpan.FromMilliseconds(200 * attempts), cancellationToken);
+      }
+    }
+  }
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/MonitoringService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/MonitoringService.cs
@@ -1,5 +1,21 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
 namespace DataPipelineApi.Services;
 public class MonitoringService : IMonitoringService
 {
-  public Task<string> GetHealthAsync() => Task.FromResult("Healthy");
+  private readonly HealthCheckService _healthChecks;
+
+  public MonitoringService(HealthCheckService healthChecks) => _healthChecks = healthChecks;
+
+  public async Task<IDictionary<string, string>> GetHealthAsync(CancellationToken cancellationToken)
+  {
+    var report = await _healthChecks.CheckHealthAsync(cancellationToken);
+    var status = report.Entries.ToDictionary(x => x.Key, x => x.Value.Status.ToString());
+    status["overall"] = report.Status.ToString();
+    return status;
+  }
 }

--- a/sample_dotnet_backend/src/DataPipelineApi/Services/StreamingService.cs
+++ b/sample_dotnet_backend/src/DataPipelineApi/Services/StreamingService.cs
@@ -1,5 +1,10 @@
+using System;
+using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using DataPipelineApi.Options;
 
@@ -7,23 +12,27 @@ namespace DataPipelineApi.Services;
 public class StreamingService : IStreamingService
 {
   private readonly HttpClient _http;
+  private readonly AirflowOptions _options;
   public StreamingService(HttpClient http, IOptions<AirflowOptions> opt)
   {
     _http = http;
-    var v = opt.Value;
-    _http.BaseAddress = new Uri(v.BaseUrl);
-    var tok = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{v.Username}:{v.Password}"));
+    _options = opt.Value;
+    if (_http.BaseAddress is null)
+      _http.BaseAddress = new Uri(_options.BaseUrl);
+    var tok = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_options.Username}:{_options.Password}"));
     _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", tok);
   }
-  public async Task<string> TriggerStreamingAsync()
+  public async Task<string> TriggerStreamingAsync(CancellationToken cancellationToken)
   {
     var id = $"stream_{DateTime.UtcNow:yyyyMMddHHmmss}";
-    await _http.PostAsJsonAsync("/dags/streaming_monitoring_dag/dagRuns", new { dag_run_id = id });
+    var resp = await _http.PostAsJsonAsync($"/dags/{_options.StreamingDagId}/dagRuns", new { dag_run_id = id }, cancellationToken);
+    resp.EnsureSuccessStatusCode();
     return id;
   }
-  public async Task<string> GetStreamingStatusAsync(string runId)
+  public async Task<string> GetStreamingStatusAsync(string runId, CancellationToken cancellationToken)
   {
-    var r = await _http.GetAsync($"/dags/streaming_monitoring_dag/dagRuns/{runId}");
-    return await r.Content.ReadAsStringAsync();
+    var r = await _http.GetAsync($"/dags/{_options.StreamingDagId}/dagRuns/{runId}", cancellationToken);
+    r.EnsureSuccessStatusCode();
+    return await r.Content.ReadAsStringAsync(cancellationToken);
   }
 }

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -1,0 +1,328 @@
+#!/bin/bash
+# Blue/Green Deployment Script with Preview and Promotion
+# Usage: ./deploy-blue-green.sh <service-name> <new-image-tag>
+
+set -e
+
+SERVICE_NAME=${1:-airflow}
+IMAGE_TAG=${2:-latest}
+NAMESPACE=${3:-default}
+
+echo "=========================================="
+echo "Starting Blue/Green Deployment"
+echo "Service: $SERVICE_NAME"
+echo "Image Tag: $IMAGE_TAG"
+echo "Namespace: $NAMESPACE"
+echo "=========================================="
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to check if Argo Rollouts is installed
+check_argo_rollouts() {
+    if ! kubectl get crd rollouts.argoproj.io &> /dev/null; then
+        echo -e "${RED}ERROR: Argo Rollouts is not installed!${NC}"
+        echo "Please install Argo Rollouts first"
+        exit 1
+    fi
+    echo -e "${GREEN}✓ Argo Rollouts is installed${NC}"
+}
+
+# Function to check if kubectl-argo-rollouts plugin is available
+check_rollouts_plugin() {
+    if ! kubectl argo rollouts version &> /dev/null; then
+        echo -e "${YELLOW}WARNING: kubectl-argo-rollouts plugin not found${NC}"
+        USE_PLUGIN=false
+    else
+        echo -e "${GREEN}✓ kubectl-argo-rollouts plugin found${NC}"
+        USE_PLUGIN=true
+    fi
+}
+
+# Function to get current active version
+get_active_version() {
+    local rollout_name="${SERVICE_NAME}-rollout"
+
+    echo -e "${BLUE}Current Active Version (Blue):${NC}"
+    kubectl get rollout "$rollout_name" -n "$NAMESPACE" \
+        -o jsonpath='{.status.stableRS}' 2>/dev/null || echo "Unknown"
+}
+
+# Function to update rollout with new image (Green)
+update_rollout() {
+    local rollout_name="${SERVICE_NAME}-rollout"
+
+    echo -e "${YELLOW}Deploying new version (Green)...${NC}"
+
+    if [[ "$USE_PLUGIN" == "true" ]]; then
+        kubectl argo rollouts set image "$rollout_name" \
+            "*=myrepo/${SERVICE_NAME}-pipeline:${IMAGE_TAG}" \
+            -n "$NAMESPACE"
+    else
+        kubectl set image rollout/"$rollout_name" \
+            "*=myrepo/${SERVICE_NAME}-pipeline:${IMAGE_TAG}" \
+            -n "$NAMESPACE"
+    fi
+
+    echo -e "${GREEN}✓ New version deployed to preview environment${NC}"
+}
+
+# Function to get preview service endpoint
+get_preview_endpoint() {
+    local preview_service="${SERVICE_NAME}-webserver-preview"
+
+    echo -e "${BLUE}Preview Service Endpoint:${NC}"
+
+    # Get service type
+    SERVICE_TYPE=$(kubectl get svc "$preview_service" -n "$NAMESPACE" -o jsonpath='{.spec.type}' 2>/dev/null || echo "")
+
+    if [[ "$SERVICE_TYPE" == "LoadBalancer" ]]; then
+        ENDPOINT=$(kubectl get svc "$preview_service" -n "$NAMESPACE" \
+            -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || \
+            kubectl get svc "$preview_service" -n "$NAMESPACE" \
+            -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || echo "Pending")
+        echo "http://${ENDPOINT}:8080"
+    elif [[ "$SERVICE_TYPE" == "ClusterIP" ]]; then
+        echo "ClusterIP service - use port-forward:"
+        echo "  kubectl port-forward -n $NAMESPACE svc/$preview_service 8081:8080"
+        echo "  Then access: http://localhost:8081"
+    else
+        echo -e "${YELLOW}Service not found or not ready${NC}"
+    fi
+}
+
+# Function to run preview analysis
+run_preview_analysis() {
+    local rollout_name="${SERVICE_NAME}-rollout"
+
+    echo -e "${YELLOW}Running preview analysis...${NC}"
+
+    # Wait for preview pods to be ready
+    echo "Waiting for preview pods to be ready..."
+    sleep 10
+
+    # Check if analysis templates exist
+    if kubectl get analysistemplate -n "$NAMESPACE" &> /dev/null; then
+        echo "Analysis templates found, checking results..."
+
+        # Get latest analysis run
+        LATEST_ANALYSIS=$(kubectl get analysisrun -n "$NAMESPACE" \
+            --sort-by=.metadata.creationTimestamp \
+            -o jsonpath='{.items[-1].metadata.name}' 2>/dev/null || echo "")
+
+        if [[ -n "$LATEST_ANALYSIS" ]]; then
+            echo "Latest analysis run: $LATEST_ANALYSIS"
+            kubectl get analysisrun "$LATEST_ANALYSIS" -n "$NAMESPACE" -o wide
+        else
+            echo -e "${YELLOW}No analysis runs found${NC}"
+        fi
+    else
+        echo -e "${YELLOW}No analysis templates configured${NC}"
+        echo "Skipping automated analysis. Please test manually."
+    fi
+}
+
+# Function to test preview environment
+test_preview() {
+    local preview_service="${SERVICE_NAME}-webserver-preview"
+
+    echo -e "${YELLOW}Testing preview environment...${NC}"
+
+    # Try to get service endpoint
+    if kubectl get svc "$preview_service" -n "$NAMESPACE" &> /dev/null; then
+        echo "Preview service exists. Testing health endpoint..."
+
+        # Port forward for testing
+        echo "Setting up port-forward for testing..."
+        kubectl port-forward -n "$NAMESPACE" svc/"$preview_service" 8081:8080 &
+        PF_PID=$!
+        sleep 5
+
+        # Test health endpoint
+        if curl -sf http://localhost:8081/health &> /dev/null; then
+            echo -e "${GREEN}✓ Health check passed${NC}"
+        else
+            echo -e "${RED}✗ Health check failed${NC}"
+        fi
+
+        # Clean up port-forward
+        kill $PF_PID 2>/dev/null || true
+    else
+        echo -e "${YELLOW}Preview service not found${NC}"
+    fi
+}
+
+# Function to promote green to blue
+promote_to_production() {
+    local rollout_name="${SERVICE_NAME}-rollout"
+
+    echo -e "${BLUE}Current deployment status:${NC}"
+    get_rollout_status
+
+    echo ""
+    echo -e "${YELLOW}This will promote the Green (preview) environment to Blue (production).${NC}"
+    echo -e "${YELLOW}Are you sure? (yes/no)${NC}"
+    read -r response
+
+    if [[ "$response" != "yes" ]]; then
+        echo "Promotion cancelled."
+        return
+    fi
+
+    echo -e "${YELLOW}Promoting Green to Blue...${NC}"
+
+    if [[ "$USE_PLUGIN" == "true" ]]; then
+        kubectl argo rollouts promote "$rollout_name" -n "$NAMESPACE"
+    else
+        # Manually promote by updating the rollout
+        kubectl patch rollout "$rollout_name" -n "$NAMESPACE" \
+            --type json -p '[{"op": "replace", "path": "/spec/strategy/blueGreen/autoPromotionEnabled", "value": true}]'
+    fi
+
+    echo -e "${GREEN}✓ Promotion initiated${NC}"
+    echo "Waiting for rollout to complete..."
+
+    # Wait for rollout
+    kubectl rollout status rollout/"$rollout_name" -n "$NAMESPACE" --timeout=10m
+
+    echo -e "${GREEN}✓ Rollout completed successfully!${NC}"
+}
+
+# Function to rollback to blue
+rollback_to_blue() {
+    local rollout_name="${SERVICE_NAME}-rollout"
+
+    echo -e "${RED}Rolling back to Blue (stable) version...${NC}"
+
+    if [[ "$USE_PLUGIN" == "true" ]]; then
+        kubectl argo rollouts abort "$rollout_name" -n "$NAMESPACE"
+        kubectl argo rollouts undo "$rollout_name" -n "$NAMESPACE"
+    else
+        kubectl rollout undo rollout/"$rollout_name" -n "$NAMESPACE"
+    fi
+
+    echo -e "${GREEN}✓ Rollback initiated${NC}"
+}
+
+# Function to get rollout status
+get_rollout_status() {
+    local rollout_name="${SERVICE_NAME}-rollout"
+
+    if [[ "$USE_PLUGIN" == "true" ]]; then
+        kubectl argo rollouts get rollout "$rollout_name" -n "$NAMESPACE"
+    else
+        kubectl get rollout "$rollout_name" -n "$NAMESPACE" -o wide
+        echo ""
+        echo "Pods:"
+        kubectl get pods -n "$NAMESPACE" -l app=pipeline,component="$SERVICE_NAME"
+    fi
+}
+
+# Function to watch rollout
+watch_rollout() {
+    local rollout_name="${SERVICE_NAME}-rollout"
+
+    echo -e "${YELLOW}Watching rollout progress...${NC}"
+
+    if [[ "$USE_PLUGIN" == "true" ]]; then
+        kubectl argo rollouts get rollout "$rollout_name" -n "$NAMESPACE" --watch
+    else
+        watch kubectl get rollout "$rollout_name" -n "$NAMESPACE"
+    fi
+}
+
+# Function to compare Blue vs Green metrics
+compare_metrics() {
+    echo -e "${BLUE}Comparing Blue vs Green Metrics:${NC}"
+
+    # Active service metrics
+    echo -e "${BLUE}Blue (Active) Metrics:${NC}"
+    kubectl top pods -n "$NAMESPACE" -l app=pipeline,component="$SERVICE_NAME" | grep -v NAME | head -3 || echo "Metrics not available"
+
+    echo ""
+    echo -e "${GREEN}Green (Preview) Metrics:${NC}"
+    kubectl top pods -n "$NAMESPACE" -l app=pipeline,component="$SERVICE_NAME" | grep -v NAME | tail -3 || echo "Metrics not available"
+}
+
+# Main menu
+show_menu() {
+    echo ""
+    echo "=========================================="
+    echo "Blue/Green Deployment Menu"
+    echo "=========================================="
+    echo "  1) Get current status"
+    echo "  2) View preview endpoint"
+    echo "  3) Test preview environment"
+    echo "  4) Run preview analysis"
+    echo "  5) Compare Blue vs Green metrics"
+    echo "  6) Promote Green to Blue (Production)"
+    echo "  7) Rollback to Blue"
+    echo "  8) Watch rollout progress"
+    echo "  9) Exit"
+    echo "=========================================="
+}
+
+# Main execution
+main() {
+    echo "Pre-flight checks..."
+    check_argo_rollouts
+    check_rollouts_plugin
+
+    echo ""
+    get_active_version
+
+    echo ""
+    echo "Deploying new version..."
+    update_rollout
+
+    echo ""
+    get_preview_endpoint
+
+    # Interactive menu
+    while true; do
+        show_menu
+        read -rp "Choose an option (1-9): " option
+
+        case $option in
+            1)
+                get_rollout_status
+                ;;
+            2)
+                get_preview_endpoint
+                ;;
+            3)
+                test_preview
+                ;;
+            4)
+                run_preview_analysis
+                ;;
+            5)
+                compare_metrics
+                ;;
+            6)
+                promote_to_production
+                ;;
+            7)
+                rollback_to_blue
+                ;;
+            8)
+                watch_rollout
+                ;;
+            9)
+                echo "Exiting. Preview environment will remain active."
+                echo "Use option 6 to promote or option 7 to rollback."
+                break
+                ;;
+            *)
+                echo -e "${RED}Invalid option${NC}"
+                ;;
+        esac
+    done
+}
+
+# Run main function
+main

--- a/scripts/deploy-canary.sh
+++ b/scripts/deploy-canary.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+# Canary Deployment Script with Progressive Traffic Shifting
+# Usage: ./deploy-canary.sh <service-name> <new-image-tag>
+
+set -e
+
+SERVICE_NAME=${1:-airflow}
+IMAGE_TAG=${2:-latest}
+NAMESPACE=${3:-default}
+
+echo "=========================================="
+echo "Starting Canary Deployment"
+echo "Service: $SERVICE_NAME"
+echo "Image Tag: $IMAGE_TAG"
+echo "Namespace: $NAMESPACE"
+echo "=========================================="
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to check if Argo Rollouts is installed
+check_argo_rollouts() {
+    if ! kubectl get crd rollouts.argoproj.io &> /dev/null; then
+        echo -e "${RED}ERROR: Argo Rollouts is not installed!${NC}"
+        echo "Please install Argo Rollouts first:"
+        echo "  kubectl create namespace argo-rollouts"
+        echo "  kubectl apply -n argo-rollouts -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml"
+        exit 1
+    fi
+    echo -e "${GREEN}✓ Argo Rollouts is installed${NC}"
+}
+
+# Function to check if kubectl-argo-rollouts plugin is available
+check_rollouts_plugin() {
+    if ! kubectl argo rollouts version &> /dev/null; then
+        echo -e "${YELLOW}WARNING: kubectl-argo-rollouts plugin not found${NC}"
+        echo "Install with: curl -LO https://github.com/argoproj/argo-rollouts/releases/latest/download/kubectl-argo-rollouts-linux-amd64"
+        echo "Using kubectl commands instead..."
+        USE_PLUGIN=false
+    else
+        echo -e "${GREEN}✓ kubectl-argo-rollouts plugin found${NC}"
+        USE_PLUGIN=true
+    fi
+}
+
+# Function to update rollout with new image
+update_rollout() {
+    local rollout_name="${SERVICE_NAME}-canary-rollout"
+
+    echo -e "${YELLOW}Updating rollout ${rollout_name} with new image...${NC}"
+
+    if [[ "$USE_PLUGIN" == "true" ]]; then
+        kubectl argo rollouts set image "$rollout_name" \
+            "*=myrepo/${SERVICE_NAME}-pipeline:${IMAGE_TAG}" \
+            -n "$NAMESPACE"
+    else
+        kubectl set image rollout/"$rollout_name" \
+            "*=myrepo/${SERVICE_NAME}-pipeline:${IMAGE_TAG}" \
+            -n "$NAMESPACE"
+    fi
+
+    echo -e "${GREEN}✓ Rollout updated with new image${NC}"
+}
+
+# Function to watch rollout status
+watch_rollout() {
+    local rollout_name="${SERVICE_NAME}-canary-rollout"
+
+    echo -e "${YELLOW}Watching rollout progress...${NC}"
+    echo "Press Ctrl+C to stop watching (rollout will continue in background)"
+
+    if [[ "$USE_PLUGIN" == "true" ]]; then
+        kubectl argo rollouts get rollout "$rollout_name" -n "$NAMESPACE" --watch
+    else
+        kubectl rollout status rollout/"$rollout_name" -n "$NAMESPACE" --watch
+    fi
+}
+
+# Function to promote canary
+promote_canary() {
+    local rollout_name="${SERVICE_NAME}-canary-rollout"
+
+    echo -e "${YELLOW}Do you want to promote the canary to stable? (y/n)${NC}"
+    read -r response
+
+    if [[ "$response" == "y" ]]; then
+        echo -e "${YELLOW}Promoting canary...${NC}"
+
+        if [[ "$USE_PLUGIN" == "true" ]]; then
+            kubectl argo rollouts promote "$rollout_name" -n "$NAMESPACE"
+        else
+            kubectl patch rollout "$rollout_name" -n "$NAMESPACE" \
+                --type json -p '[{"op": "replace", "path": "/spec/strategy/canary/steps", "value": [{"setWeight": 100}]}]'
+        fi
+
+        echo -e "${GREEN}✓ Canary promoted to stable${NC}"
+    else
+        echo -e "${YELLOW}Promotion cancelled. Canary will continue at current weight.${NC}"
+    fi
+}
+
+# Function to abort rollout
+abort_rollout() {
+    local rollout_name="${SERVICE_NAME}-canary-rollout"
+
+    echo -e "${RED}Aborting rollout...${NC}"
+
+    if [[ "$USE_PLUGIN" == "true" ]]; then
+        kubectl argo rollouts abort "$rollout_name" -n "$NAMESPACE"
+    else
+        kubectl patch rollout "$rollout_name" -n "$NAMESPACE" \
+            --type merge -p '{"spec":{"paused":true}}'
+    fi
+
+    echo -e "${GREEN}✓ Rollout aborted${NC}"
+}
+
+# Function to get rollout status
+get_rollout_status() {
+    local rollout_name="${SERVICE_NAME}-canary-rollout"
+
+    echo -e "${YELLOW}Current Rollout Status:${NC}"
+
+    if [[ "$USE_PLUGIN" == "true" ]]; then
+        kubectl argo rollouts get rollout "$rollout_name" -n "$NAMESPACE"
+    else
+        kubectl get rollout "$rollout_name" -n "$NAMESPACE" -o wide
+    fi
+}
+
+# Function to get analysis runs
+get_analysis_runs() {
+    echo -e "${YELLOW}Recent Analysis Runs:${NC}"
+    kubectl get analysisruns -n "$NAMESPACE" --sort-by=.metadata.creationTimestamp | tail -10
+}
+
+# Function to check metrics
+check_metrics() {
+    echo -e "${YELLOW}Checking canary metrics...${NC}"
+
+    # Check if Prometheus is available
+    if kubectl get svc prometheus -n "$NAMESPACE" &> /dev/null; then
+        echo "Success Rate:"
+        kubectl exec -n "$NAMESPACE" svc/prometheus -- \
+            wget -qO- 'http://localhost:9090/api/v1/query?query=sum(rate(http_requests_total{service=~".*-canary",status=~"2.."}[5m]))/sum(rate(http_requests_total{service=~".*-canary"}[5m]))' \
+            | jq '.data.result[0].value[1]' 2>/dev/null || echo "Unable to fetch metrics"
+    else
+        echo -e "${YELLOW}Prometheus not available in namespace${NC}"
+    fi
+}
+
+# Main execution
+main() {
+    echo "Pre-flight checks..."
+    check_argo_rollouts
+    check_rollouts_plugin
+
+    echo ""
+    echo "Starting deployment..."
+    update_rollout
+
+    echo ""
+    get_rollout_status
+
+    echo ""
+    echo "Options:"
+    echo "  1) Watch rollout progress"
+    echo "  2) Promote canary"
+    echo "  3) Abort rollout"
+    echo "  4) Check metrics"
+    echo "  5) View analysis runs"
+    echo "  6) Exit"
+
+    while true; do
+        echo ""
+        read -rp "Choose an option (1-6): " option
+
+        case $option in
+            1)
+                watch_rollout
+                ;;
+            2)
+                promote_canary
+                ;;
+            3)
+                abort_rollout
+                break
+                ;;
+            4)
+                check_metrics
+                ;;
+            5)
+                get_analysis_runs
+                ;;
+            6)
+                echo "Exiting. Rollout will continue in background."
+                echo "Use 'kubectl argo rollouts get rollout ${SERVICE_NAME}-canary-rollout -n ${NAMESPACE}' to check status"
+                break
+                ;;
+            *)
+                echo "Invalid option"
+                ;;
+        esac
+    done
+}
+
+# Run main function
+main

--- a/scripts/setup-advanced-deployments.sh
+++ b/scripts/setup-advanced-deployments.sh
@@ -1,0 +1,321 @@
+#!/bin/bash
+# Setup Script for Advanced Deployment Infrastructure
+# Installs: Argo Rollouts, AWS Load Balancer Controller, Nginx Ingress, Prometheus Operator
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo "=========================================="
+echo "Advanced Deployment Infrastructure Setup"
+echo "=========================================="
+
+# Configuration
+EKS_CLUSTER_NAME=${EKS_CLUSTER_NAME:-"end-to-end-pipeline"}
+AWS_REGION=${AWS_REGION:-"us-east-1"}
+INSTALL_ARGO_ROLLOUTS=${INSTALL_ARGO_ROLLOUTS:-true}
+INSTALL_AWS_LB_CONTROLLER=${INSTALL_AWS_LB_CONTROLLER:-true}
+INSTALL_NGINX_INGRESS=${INSTALL_NGINX_INGRESS:-true}
+INSTALL_PROMETHEUS=${INSTALL_PROMETHEUS:-true}
+
+# Function to check prerequisites
+check_prerequisites() {
+    echo -e "${BLUE}Checking prerequisites...${NC}"
+
+    # Check kubectl
+    if ! command -v kubectl &> /dev/null; then
+        echo -e "${RED}ERROR: kubectl not found${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✓ kubectl found${NC}"
+
+    # Check helm
+    if ! command -v helm &> /dev/null; then
+        echo -e "${RED}ERROR: helm not found${NC}"
+        echo "Install helm: https://helm.sh/docs/intro/install/"
+        exit 1
+    fi
+    echo -e "${GREEN}✓ helm found${NC}"
+
+    # Check cluster connection
+    if ! kubectl cluster-info &> /dev/null; then
+        echo -e "${RED}ERROR: Cannot connect to Kubernetes cluster${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✓ Connected to Kubernetes cluster${NC}"
+
+    # Check AWS CLI (if installing AWS LB Controller)
+    if [[ "$INSTALL_AWS_LB_CONTROLLER" == "true" ]]; then
+        if ! command -v aws &> /dev/null; then
+            echo -e "${YELLOW}WARNING: AWS CLI not found. Skipping AWS Load Balancer Controller.${NC}"
+            INSTALL_AWS_LB_CONTROLLER=false
+        else
+            echo -e "${GREEN}✓ AWS CLI found${NC}"
+        fi
+    fi
+}
+
+# Function to install Argo Rollouts
+install_argo_rollouts() {
+    echo ""
+    echo -e "${BLUE}Installing Argo Rollouts...${NC}"
+
+    # Create namespace
+    kubectl create namespace argo-rollouts --dry-run=client -o yaml | kubectl apply -f -
+
+    # Add Argo Helm repository
+    helm repo add argo https://argoproj.github.io/argo-helm
+    helm repo update
+
+    # Install Argo Rollouts
+    helm upgrade --install argo-rollouts argo/argo-rollouts \
+        --namespace argo-rollouts \
+        --set dashboard.enabled=true \
+        --set controller.metrics.enabled=true \
+        --set controller.metrics.serviceMonitor.enabled=true \
+        --wait
+
+    echo -e "${GREEN}✓ Argo Rollouts installed${NC}"
+
+    # Install kubectl plugin
+    echo "Installing kubectl-argo-rollouts plugin..."
+    curl -LO https://github.com/argoproj/argo-rollouts/releases/latest/download/kubectl-argo-rollouts-linux-amd64
+    chmod +x kubectl-argo-rollouts-linux-amd64
+    sudo mv kubectl-argo-rollouts-linux-amd64 /usr/local/bin/kubectl-argo-rollouts
+
+    echo -e "${GREEN}✓ kubectl-argo-rollouts plugin installed${NC}"
+}
+
+# Function to install AWS Load Balancer Controller
+install_aws_lb_controller() {
+    echo ""
+    echo -e "${BLUE}Installing AWS Load Balancer Controller...${NC}"
+
+    # Download IAM policy
+    curl -o iam_policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/install/iam_policy.json
+
+    # Create IAM policy
+    aws iam create-policy \
+        --policy-name AWSLoadBalancerControllerIAMPolicy \
+        --policy-document file://iam_policy.json \
+        2>/dev/null || echo "Policy already exists, continuing..."
+
+    # Get AWS account ID
+    AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+    # Create IAM service account
+    eksctl create iamserviceaccount \
+        --cluster="$EKS_CLUSTER_NAME" \
+        --namespace=kube-system \
+        --name=aws-load-balancer-controller \
+        --attach-policy-arn=arn:aws:iam::"$AWS_ACCOUNT_ID":policy/AWSLoadBalancerControllerIAMPolicy \
+        --override-existing-serviceaccounts \
+        --approve
+
+    # Add EKS Helm repository
+    helm repo add eks https://aws.github.io/eks-charts
+    helm repo update
+
+    # Install AWS Load Balancer Controller
+    helm upgrade --install aws-load-balancer-controller eks/aws-load-balancer-controller \
+        --namespace kube-system \
+        --set clusterName="$EKS_CLUSTER_NAME" \
+        --set serviceAccount.create=false \
+        --set serviceAccount.name=aws-load-balancer-controller \
+        --set region="$AWS_REGION" \
+        --set vpcId=$(aws eks describe-cluster --name "$EKS_CLUSTER_NAME" --query "cluster.resourcesVpcConfig.vpcId" --output text) \
+        --wait
+
+    echo -e "${GREEN}✓ AWS Load Balancer Controller installed${NC}"
+
+    # Cleanup
+    rm -f iam_policy.json
+}
+
+# Function to install Nginx Ingress Controller
+install_nginx_ingress() {
+    echo ""
+    echo -e "${BLUE}Installing Nginx Ingress Controller...${NC}"
+
+    # Add Nginx Helm repository
+    helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+    helm repo update
+
+    # Install Nginx Ingress
+    helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
+        --namespace ingress-nginx \
+        --create-namespace \
+        --set controller.metrics.enabled=true \
+        --set controller.metrics.serviceMonitor.enabled=true \
+        --set controller.podAnnotations."prometheus\.io/scrape"=true \
+        --set controller.podAnnotations."prometheus\.io/port"=10254 \
+        --wait
+
+    echo -e "${GREEN}✓ Nginx Ingress Controller installed${NC}"
+}
+
+# Function to install Prometheus Operator
+install_prometheus() {
+    echo ""
+    echo -e "${BLUE}Installing Prometheus Operator...${NC}"
+
+    # Add Prometheus Helm repository
+    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    helm repo update
+
+    # Install kube-prometheus-stack
+    helm upgrade --install kube-prometheus prometheus-community/kube-prometheus-stack \
+        --namespace monitoring \
+        --create-namespace \
+        --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false \
+        --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false \
+        --set prometheus.prometheusSpec.ruleSelectorNilUsesHelmValues=false \
+        --set grafana.enabled=true \
+        --set grafana.adminPassword=admin \
+        --set alertmanager.enabled=true \
+        --wait
+
+    echo -e "${GREEN}✓ Prometheus Operator installed${NC}"
+
+    # Get Grafana password
+    echo ""
+    echo -e "${YELLOW}Grafana credentials:${NC}"
+    echo "  Username: admin"
+    echo "  Password: admin"
+    echo ""
+    echo "Access Grafana:"
+    echo "  kubectl port-forward -n monitoring svc/kube-prometheus-grafana 3000:80"
+    echo "  Then open: http://localhost:3000"
+}
+
+# Function to apply Kubernetes manifests
+apply_manifests() {
+    echo ""
+    echo -e "${BLUE}Applying Kubernetes manifests...${NC}"
+
+    MANIFESTS_DIR="../kubernetes"
+
+    if [[ -f "$MANIFESTS_DIR/services.yaml" ]]; then
+        kubectl apply -f "$MANIFESTS_DIR/services.yaml"
+        echo -e "${GREEN}✓ Services applied${NC}"
+    fi
+
+    if [[ -f "$MANIFESTS_DIR/analysis-templates.yaml" ]]; then
+        kubectl apply -f "$MANIFESTS_DIR/analysis-templates.yaml"
+        echo -e "${GREEN}✓ Analysis templates applied${NC}"
+    fi
+
+    if [[ -f "$MANIFESTS_DIR/servicemonitors.yaml" ]]; then
+        kubectl apply -f "$MANIFESTS_DIR/servicemonitors.yaml"
+        echo -e "${GREEN}✓ ServiceMonitors applied${NC}"
+    fi
+
+    echo -e "${GREEN}✓ All manifests applied${NC}"
+}
+
+# Function to verify installation
+verify_installation() {
+    echo ""
+    echo -e "${BLUE}Verifying installation...${NC}"
+
+    # Check Argo Rollouts
+    if [[ "$INSTALL_ARGO_ROLLOUTS" == "true" ]]; then
+        if kubectl get pods -n argo-rollouts | grep -q Running; then
+            echo -e "${GREEN}✓ Argo Rollouts is running${NC}"
+        else
+            echo -e "${RED}✗ Argo Rollouts is not running${NC}"
+        fi
+    fi
+
+    # Check AWS Load Balancer Controller
+    if [[ "$INSTALL_AWS_LB_CONTROLLER" == "true" ]]; then
+        if kubectl get pods -n kube-system | grep aws-load-balancer-controller | grep -q Running; then
+            echo -e "${GREEN}✓ AWS Load Balancer Controller is running${NC}"
+        else
+            echo -e "${RED}✗ AWS Load Balancer Controller is not running${NC}"
+        fi
+    fi
+
+    # Check Nginx Ingress
+    if [[ "$INSTALL_NGINX_INGRESS" == "true" ]]; then
+        if kubectl get pods -n ingress-nginx | grep -q Running; then
+            echo -e "${GREEN}✓ Nginx Ingress is running${NC}"
+        else
+            echo -e "${RED}✗ Nginx Ingress is not running${NC}"
+        fi
+    fi
+
+    # Check Prometheus
+    if [[ "$INSTALL_PROMETHEUS" == "true" ]]; then
+        if kubectl get pods -n monitoring | grep prometheus | grep -q Running; then
+            echo -e "${GREEN}✓ Prometheus is running${NC}"
+        else
+            echo -e "${RED}✗ Prometheus is not running${NC}"
+        fi
+    fi
+}
+
+# Function to print next steps
+print_next_steps() {
+    echo ""
+    echo "=========================================="
+    echo -e "${GREEN}Installation Complete!${NC}"
+    echo "=========================================="
+    echo ""
+    echo "Next Steps:"
+    echo ""
+    echo "1. Deploy using Blue/Green strategy:"
+    echo "   ./deploy-blue-green.sh airflow v1.0.0"
+    echo ""
+    echo "2. Deploy using Canary strategy:"
+    echo "   ./deploy-canary.sh airflow v1.0.0"
+    echo ""
+    echo "3. Access Argo Rollouts dashboard:"
+    echo "   kubectl port-forward -n argo-rollouts svc/argo-rollouts-dashboard 3100:3100"
+    echo "   Then open: http://localhost:3100"
+    echo ""
+    echo "4. Access Grafana dashboard:"
+    echo "   kubectl port-forward -n monitoring svc/kube-prometheus-grafana 3000:80"
+    echo "   Then open: http://localhost:3000 (admin/admin)"
+    echo ""
+    echo "5. View rollouts:"
+    echo "   kubectl argo rollouts list"
+    echo ""
+    echo "6. Apply rollout manifests:"
+    echo "   kubectl apply -f ../kubernetes/rollout-blue-green.yaml"
+    echo "   kubectl apply -f ../kubernetes/rollout-canary.yaml"
+    echo ""
+}
+
+# Main execution
+main() {
+    check_prerequisites
+
+    if [[ "$INSTALL_ARGO_ROLLOUTS" == "true" ]]; then
+        install_argo_rollouts
+    fi
+
+    if [[ "$INSTALL_AWS_LB_CONTROLLER" == "true" ]]; then
+        install_aws_lb_controller
+    fi
+
+    if [[ "$INSTALL_NGINX_INGRESS" == "true" ]]; then
+        install_nginx_ingress
+    fi
+
+    if [[ "$INSTALL_PROMETHEUS" == "true" ]]; then
+        install_prometheus
+    fi
+
+    apply_manifests
+    verify_installation
+    print_next_steps
+}
+
+# Run main function
+main

--- a/terraform/argo-rollouts.tf
+++ b/terraform/argo-rollouts.tf
@@ -1,0 +1,282 @@
+# Argo Rollouts Infrastructure
+# Enables advanced deployment strategies: Blue/Green, Canary, Progressive Delivery
+
+# Namespace for Argo Rollouts
+resource "kubernetes_namespace" "argo_rollouts" {
+  metadata {
+    name = "argo-rollouts"
+
+    labels = {
+      name    = "argo-rollouts"
+      purpose = "progressive-delivery"
+    }
+  }
+}
+
+# Helm release for Argo Rollouts
+resource "helm_release" "argo_rollouts" {
+  name       = "argo-rollouts"
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argo-rollouts"
+  namespace  = kubernetes_namespace.argo_rollouts.metadata[0].name
+  version    = "2.32.0"
+
+  values = [
+    yamlencode({
+      # Controller configuration
+      controller = {
+        replicas = 2
+
+        resources = {
+          limits = {
+            cpu    = "500m"
+            memory = "512Mi"
+          }
+          requests = {
+            cpu    = "250m"
+            memory = "256Mi"
+          }
+        }
+
+        # Enable metrics
+        metrics = {
+          enabled      = true
+          serviceMonitor = {
+            enabled = true
+          }
+        }
+
+        # Enable notifications
+        notifications = {
+          enabled = true
+          secret = {
+            create = true
+            items = {
+              slack-token = ""  # Add your Slack token here or use external secret
+            }
+          }
+        }
+      }
+
+      # Dashboard configuration
+      dashboard = {
+        enabled = true
+
+        service = {
+          type = "LoadBalancer"
+          port = 3100
+        }
+
+        ingress = {
+          enabled = false  # Enable if you want ingress
+          annotations = {
+            "kubernetes.io/ingress.class"                = "nginx"
+            "cert-manager.io/cluster-issuer"             = "letsencrypt-prod"
+            "nginx.ingress.kubernetes.io/ssl-redirect"   = "true"
+          }
+          hosts = [
+            {
+              host = "rollouts.yourdomain.com"
+              paths = [
+                {
+                  path     = "/"
+                  pathType = "Prefix"
+                }
+              ]
+            }
+          ]
+        }
+      }
+
+      # Service account
+      serviceAccount = {
+        create = true
+        name   = "argo-rollouts"
+      }
+    })
+  ]
+
+  depends_on = [
+    kubernetes_namespace.argo_rollouts
+  ]
+}
+
+# Install Argo Rollouts kubectl plugin via init container approach
+resource "kubernetes_config_map" "rollouts_plugin_installer" {
+  metadata {
+    name      = "rollouts-plugin-installer"
+    namespace = kubernetes_namespace.argo_rollouts.metadata[0].name
+  }
+
+  data = {
+    "install.sh" = <<-EOT
+      #!/bin/bash
+      set -e
+
+      # Download kubectl-argo-rollouts plugin
+      curl -LO https://github.com/argoproj/argo-rollouts/releases/latest/download/kubectl-argo-rollouts-linux-amd64
+      chmod +x kubectl-argo-rollouts-linux-amd64
+      mv kubectl-argo-rollouts-linux-amd64 /usr/local/bin/kubectl-argo-rollouts
+
+      echo "Argo Rollouts plugin installed successfully"
+    EOT
+  }
+}
+
+# RBAC for Argo Rollouts to manage deployments
+resource "kubernetes_cluster_role" "argo_rollouts_aggregate" {
+  metadata {
+    name = "argo-rollouts-aggregate-to-admin"
+
+    labels = {
+      "rbac.authorization.k8s.io/aggregate-to-admin" = "true"
+      "rbac.authorization.k8s.io/aggregate-to-edit"  = "true"
+    }
+  }
+
+  rule {
+    api_groups = ["argoproj.io"]
+    resources  = ["rollouts", "rollouts/status", "experiments", "analysisruns", "analysistemplates"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+}
+
+# Service Monitor for Prometheus (if using Prometheus Operator)
+resource "kubernetes_manifest" "argo_rollouts_servicemonitor" {
+  manifest = {
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "ServiceMonitor"
+
+    metadata = {
+      name      = "argo-rollouts-metrics"
+      namespace = kubernetes_namespace.argo_rollouts.metadata[0].name
+
+      labels = {
+        app                          = "argo-rollouts"
+        "app.kubernetes.io/name"     = "argo-rollouts-metrics"
+        "app.kubernetes.io/instance" = "argo-rollouts"
+      }
+    }
+
+    spec = {
+      selector = {
+        matchLabels = {
+          "app.kubernetes.io/name" = "argo-rollouts-metrics"
+        }
+      }
+
+      endpoints = [
+        {
+          port     = "metrics"
+          interval = "30s"
+          path     = "/metrics"
+        }
+      ]
+    }
+  }
+
+  depends_on = [helm_release.argo_rollouts]
+}
+
+# Notification Secret for Argo Rollouts
+resource "kubernetes_secret" "argo_rollouts_notification" {
+  metadata {
+    name      = "argo-rollouts-notification-secret"
+    namespace = kubernetes_namespace.argo_rollouts.metadata[0].name
+  }
+
+  data = {
+    slack-token = base64encode(var.slack_webhook_url)
+  }
+
+  type = "Opaque"
+}
+
+# ConfigMap for Argo Rollouts notifications
+resource "kubernetes_config_map" "argo_rollouts_notification_config" {
+  metadata {
+    name      = "argo-rollouts-notification-configmap"
+    namespace = kubernetes_namespace.argo_rollouts.metadata[0].name
+  }
+
+  data = {
+    "service.slack" = <<-EOT
+      token: $slack-token
+    EOT
+
+    "template.rollout-updated" = <<-EOT
+      message: |
+        Rollout {{.rollout.metadata.name}} has been updated.
+        Namespace: {{.rollout.metadata.namespace}}
+        Phase: {{.rollout.status.phase}}
+    EOT
+
+    "template.rollout-step-completed" = <<-EOT
+      message: |
+        ✅ Rollout {{.rollout.metadata.name}} completed step {{.rollout.status.currentStepIndex}}.
+        Phase: {{.rollout.status.phase}}
+    EOT
+
+    "template.rollout-aborted" = <<-EOT
+      message: |
+        ⚠️ Rollout {{.rollout.metadata.name}} has been ABORTED!
+        Namespace: {{.rollout.metadata.namespace}}
+        Message: {{.rollout.status.message}}
+    EOT
+
+    "template.rollout-completed" = <<-EOT
+      message: |
+        🎉 Rollout {{.rollout.metadata.name}} completed successfully!
+        Namespace: {{.rollout.metadata.namespace}}
+    EOT
+
+    "template.analysis-run-failed" = <<-EOT
+      message: |
+        ❌ Analysis Run {{.analysisRun.metadata.name}} FAILED!
+        Rollout: {{.analysisRun.metadata.labels.rollout}}
+        Message: {{.analysisRun.status.message}}
+    EOT
+
+    "trigger.on-rollout-updated" = <<-EOT
+      - send: [rollout-updated]
+    EOT
+
+    "trigger.on-rollout-step-completed" = <<-EOT
+      - send: [rollout-step-completed]
+    EOT
+
+    "trigger.on-rollout-completed" = <<-EOT
+      - when: rollout.status.phase == 'Healthy'
+        send: [rollout-completed]
+    EOT
+
+    "trigger.on-rollout-aborted" = <<-EOT
+      - when: rollout.status.phase == 'Degraded'
+        send: [rollout-aborted]
+    EOT
+
+    "trigger.on-analysis-run-failed" = <<-EOT
+      - when: analysisRun.status.phase == 'Failed'
+        send: [analysis-run-failed]
+    EOT
+  }
+}
+
+# Variables
+variable "slack_webhook_url" {
+  description = "Slack webhook URL for Argo Rollouts notifications"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+# Outputs
+output "argo_rollouts_namespace" {
+  description = "Namespace where Argo Rollouts is installed"
+  value       = kubernetes_namespace.argo_rollouts.metadata[0].name
+}
+
+output "argo_rollouts_dashboard_url" {
+  description = "URL for Argo Rollouts dashboard (if LoadBalancer)"
+  value       = "Check kubectl get svc -n ${kubernetes_namespace.argo_rollouts.metadata[0].name} for LoadBalancer IP"
+}

--- a/terraform/load-balancer-controller.tf
+++ b/terraform/load-balancer-controller.tf
@@ -1,0 +1,343 @@
+# AWS Load Balancer Controller for EKS
+# This enables advanced ingress capabilities including ALB and NLB integration
+
+# IAM Role for AWS Load Balancer Controller
+resource "aws_iam_role" "aws_load_balancer_controller" {
+  name = "aws-load-balancer-controller-${var.eks_cluster_name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.eks.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${replace(aws_iam_openid_connect_provider.eks.url, "https://", "")}:sub" : "system:serviceaccount:kube-system:aws-load-balancer-controller"
+            "${replace(aws_iam_openid_connect_provider.eks.url, "https://", "")}:aud" : "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "AWSLoadBalancerControllerRole"
+    Environment = "production"
+    ManagedBy   = "terraform"
+  }
+}
+
+# OIDC Provider for EKS (required for IRSA - IAM Roles for Service Accounts)
+data "tls_certificate" "eks" {
+  url = aws_eks_cluster.main.identity[0].oidc[0].issuer
+}
+
+resource "aws_iam_openid_connect_provider" "eks" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.eks.certificates[0].sha1_fingerprint]
+  url             = aws_eks_cluster.main.identity[0].oidc[0].issuer
+
+  tags = {
+    Name = "${var.eks_cluster_name}-eks-oidc"
+  }
+}
+
+# IAM Policy for AWS Load Balancer Controller
+resource "aws_iam_policy" "aws_load_balancer_controller" {
+  name        = "AWSLoadBalancerControllerIAMPolicy-${var.eks_cluster_name}"
+  description = "IAM policy for AWS Load Balancer Controller"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "iam:CreateServiceLinkedRole"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "iam:AWSServiceName" = "elasticloadbalancing.amazonaws.com"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeAccountAttributes",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeInternetGateways",
+          "ec2:DescribeVpcs",
+          "ec2:DescribeVpcPeeringConnections",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeInstances",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeTags",
+          "ec2:GetCoipPoolUsage",
+          "ec2:DescribeCoipPools",
+          "elasticloadbalancing:DescribeLoadBalancers",
+          "elasticloadbalancing:DescribeLoadBalancerAttributes",
+          "elasticloadbalancing:DescribeListeners",
+          "elasticloadbalancing:DescribeListenerCertificates",
+          "elasticloadbalancing:DescribeSSLPolicies",
+          "elasticloadbalancing:DescribeRules",
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:DescribeTargetGroupAttributes",
+          "elasticloadbalancing:DescribeTargetHealth",
+          "elasticloadbalancing:DescribeTags"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "cognito-idp:DescribeUserPoolClient",
+          "acm:ListCertificates",
+          "acm:DescribeCertificate",
+          "iam:ListServerCertificates",
+          "iam:GetServerCertificate",
+          "waf-regional:GetWebACL",
+          "waf-regional:GetWebACLForResource",
+          "waf-regional:AssociateWebACL",
+          "waf-regional:DisassociateWebACL",
+          "wafv2:GetWebACL",
+          "wafv2:GetWebACLForResource",
+          "wafv2:AssociateWebACL",
+          "wafv2:DisassociateWebACL",
+          "shield:GetSubscriptionState",
+          "shield:DescribeProtection",
+          "shield:CreateProtection",
+          "shield:DeleteProtection"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress",
+          "ec2:CreateSecurityGroup"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateTags"
+        ]
+        Resource = "arn:aws:ec2:*:*:security-group/*"
+        Condition = {
+          StringEquals = {
+            "ec2:CreateAction" = "CreateSecurityGroup"
+          }
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateTags",
+          "ec2:DeleteTags"
+        ]
+        Resource = "arn:aws:ec2:*:*:security-group/*"
+        Condition = {
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster"  = "true"
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:CreateLoadBalancer",
+          "elasticloadbalancing:CreateTargetGroup"
+        ]
+        Resource = "*"
+        Condition = {
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:CreateListener",
+          "elasticloadbalancing:DeleteListener",
+          "elasticloadbalancing:CreateRule",
+          "elasticloadbalancing:DeleteRule"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags"
+        ]
+        Resource = [
+          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+        ]
+        Condition = {
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster"  = "true"
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:ModifyLoadBalancerAttributes",
+          "elasticloadbalancing:SetIpAddressType",
+          "elasticloadbalancing:SetSecurityGroups",
+          "elasticloadbalancing:SetSubnets",
+          "elasticloadbalancing:DeleteLoadBalancer",
+          "elasticloadbalancing:ModifyTargetGroup",
+          "elasticloadbalancing:ModifyTargetGroupAttributes",
+          "elasticloadbalancing:DeleteTargetGroup"
+        ]
+        Resource = "*"
+        Condition = {
+          Null = {
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:RegisterTargets",
+          "elasticloadbalancing:DeregisterTargets"
+        ]
+        Resource = "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+      }
+    ]
+  })
+}
+
+# Attach policy to role
+resource "aws_iam_role_policy_attachment" "aws_load_balancer_controller" {
+  policy_arn = aws_iam_policy.aws_load_balancer_controller.arn
+  role       = aws_iam_role.aws_load_balancer_controller.name
+}
+
+# Helm release for AWS Load Balancer Controller
+resource "helm_release" "aws_load_balancer_controller" {
+  name       = "aws-load-balancer-controller"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-load-balancer-controller"
+  namespace  = "kube-system"
+  version    = "1.6.0"
+
+  set {
+    name  = "clusterName"
+    value = var.eks_cluster_name
+  }
+
+  set {
+    name  = "serviceAccount.create"
+    value = "true"
+  }
+
+  set {
+    name  = "serviceAccount.name"
+    value = "aws-load-balancer-controller"
+  }
+
+  set {
+    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+    value = aws_iam_role.aws_load_balancer_controller.arn
+  }
+
+  set {
+    name  = "region"
+    value = var.aws_region
+  }
+
+  set {
+    name  = "vpcId"
+    value = aws_vpc.main.id
+  }
+
+  # Enable WAF support
+  set {
+    name  = "enableWaf"
+    value = "true"
+  }
+
+  # Enable Shield support
+  set {
+    name  = "enableShield"
+    value = "true"
+  }
+
+  depends_on = [
+    aws_eks_cluster.main,
+    aws_iam_role_policy_attachment.aws_load_balancer_controller
+  ]
+}
+
+# VPC for EKS (if not already defined)
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name                                           = "${var.eks_cluster_name}-vpc"
+    "kubernetes.io/cluster/${var.eks_cluster_name}" = "shared"
+  }
+}
+
+# Security Group for Ingress
+resource "aws_security_group" "pipeline_ingress_sg" {
+  name        = "pipeline-ingress-sg"
+  description = "Security group for pipeline ingress traffic"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "pipeline-ingress-sg"
+  }
+}
+
+# Output
+output "load_balancer_controller_role_arn" {
+  description = "ARN of the IAM role for AWS Load Balancer Controller"
+  value       = aws_iam_role.aws_load_balancer_controller.arn
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,38 @@
+# Terraform Variables Configuration Example
+# Copy this file to terraform.tfvars and customize for your environment
+
+# AWS Configuration
+aws_region = "us-east-1"
+
+# EKS Cluster Configuration
+eks_cluster_name = "end-to-end-pipeline"
+
+# Instance Configuration
+instance_type = "t3.medium"
+
+# Database Configuration
+db_username = "admin"
+db_password = "CHANGE_ME_TO_SECURE_PASSWORD"
+
+# Notification Configuration
+# Get your Slack webhook from: https://api.slack.com/messaging/webhooks
+slack_webhook_url = ""
+
+# Deployment Strategy Configuration
+enable_blue_green = true
+enable_canary     = true
+
+# Canary Deployment Settings
+canary_initial_weight = 10  # Start with 10% traffic to canary
+
+# Monitoring Configuration
+enable_monitoring = true
+
+# Additional Configuration (optional)
+# Uncomment and customize as needed
+
+# tags = {
+#   Environment = "production"
+#   Project     = "data-pipeline"
+#   ManagedBy   = "terraform"
+# }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -21,3 +21,34 @@ variable "eks_cluster_name" {
   description = "EKS Cluster Name"
   default     = "end-to-end-pipeline"
 }
+
+variable "slack_webhook_url" {
+  description = "Slack webhook URL for deployment notifications"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "enable_blue_green" {
+  description = "Enable blue/green deployment strategy"
+  type        = bool
+  default     = true
+}
+
+variable "enable_canary" {
+  description = "Enable canary deployment strategy"
+  type        = bool
+  default     = true
+}
+
+variable "canary_initial_weight" {
+  description = "Initial traffic weight for canary deployments (percentage)"
+  type        = number
+  default     = 10
+}
+
+variable "enable_monitoring" {
+  description = "Enable Prometheus and Grafana monitoring"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This pull request introduces several major improvements to the Kubernetes infrastructure and documentation for the data pipeline project. The most significant changes include the addition of comprehensive monitoring and analysis templates for key pipeline components, enhanced ingress configurations for both AWS ALB and Nginx controllers, and new resources to support Argo Rollouts for progressive delivery. Additionally, the pipeline architecture diagram in the `README.md` has been modernized using Mermaid for better clarity and maintainability.

**Kubernetes Infrastructure Enhancements**

* Added detailed `AnalysisTemplate` resources for monitoring success rate, latency, Airflow health, Kafka health, Spark job health, and overall service health using Prometheus queries in `kubernetes/analysis-templates.yaml`. Also included an HTTP health check template for web endpoints.
* Introduced ingress configurations for both AWS Load Balancer (ALB) and Nginx Ingress Controller, supporting multiple pipeline services (Airflow, Spark, Grafana), with annotations for traffic management, security, rate limiting, SSL/TLS, and CORS in `kubernetes/ingress.yaml`.
* Added Argo Rollouts installation resources, including ConfigMaps for metrics and notifications, ServiceAccount, ClusterRole, and a dashboard service, enabling progressive delivery and integration with Prometheus and Slack in `kubernetes/argo-rollouts-install.yaml`.

**Documentation Improvements**

* Updated the pipeline architecture diagram in `README.md` to use Mermaid syntax, grouping components by theme and improving visualization of batch, streaming, monitoring, ML, CI/CD, and orchestration layers.

**IDE/Project Migration State**

* Added migration state files for Copilot data pipeline agents, marking migrations as completed for Agent, Ask, Ask2Agent, and Edit components in the `.idea` directory. [[1]](diffhunk://#diff-fc08b5335fd8667dfc6a6d22d262f8c60cbdda0c00094ee161627b6c4e6f6ea4R1-R6) [[2]](diffhunk://#diff-d5798d2ba7d178b4af1dce13148240df97ba7a3557c0c7eefb68f33bb00ab567R1-R6) [[3]](diffhunk://#diff-e5d9a6c923b4b054af0508e997183314be9401f8315f3c3147c88053bc1cf704R1-R6) [[4]](diffhunk://#diff-465f44f69e049ee08126a997b312c14e3e6bb7c36be8243f0cffcb278d8cb1c5R1-R6)