### PR TITLE
fix: restore 'Features' link in navigation menu of index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,8 +37,8 @@
             <ul class="nav-menu">
                 <li><a href="#overview" class="nav-link">Overview</a></li>
                 <li><a href="#architecture" class="nav-link">Architecture</a></li>
-                <li><a href="#features" class="nav-link">Features</a></li>
                 <li><a href="#technologies" class="nav-link">Technologies</a></li>
+                <li><a href="#features" class="nav-link">Features</a></li>
                 <li><a href="#deployment" class="nav-link">Deployment</a></li>
                 <li><a href="#getting-started" class="nav-link">Get Started</a></li>
                 <li><a href="https://github.com/hoangsonww/End-to-End-Data-Pipeline" class="cta-button">GitHub</a></li>


### PR DESCRIPTION
This pull request makes a minor update to the navigation menu in `index.html`. The order of the "Features" link has been corrected so that it appears after "Architecture" and before "Technologies" in the menu.

([index.htmlL40-R41](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L40-R41))