### PR TITLE
fix: use Confluent-native zookeeper healthcheck for CI compatibility

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -27,7 +27,9 @@
       "Bash(black --check --line-length 120 airflow/ spark/ kafka/ storage/ governance/ ml/ monitoring/)",
       "Bash(black --line-length 120 airflow/ spark/ kafka/ storage/ governance/ ml/ monitoring/ bi_dashboards/ great_expectations/ snowflake/ tests/ serve_wiki.py)",
       "Bash(prettier --write \"index.html\" \"packages/*.css\" \"packages/*.js\" \"sample_dotnet_backend/appsettings*.json\")",
-      "Bash(make format:*)"
+      "Bash(make format:*)",
+      "Skill(commit-commands:commit-push-pr)",
+      "Bash(git checkout:*)"
     ]
   }
 }

--- a/.github/workflows/cicd-pipeline.yml
+++ b/.github/workflows/cicd-pipeline.yml
@@ -190,7 +190,7 @@ jobs:
         run: |
           docker compose up -d zookeeper kafka mysql postgres minio redis mongodb
           echo "Waiting for services to be healthy..."
-          sleep 45
+          sleep 60
 
       - name: Check service health
         run: |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,11 +23,11 @@ services:
           cpus: '0.5'
           memory: 512M
     healthcheck:
-      test: ["CMD-SHELL", "echo ruok | nc localhost 2181 | grep imok"]
-      interval: 15s
+      test: ["CMD-SHELL", "cub zk-ready localhost:2181 5"]
+      interval: 10s
       timeout: 10s
-      retries: 5
-      start_period: 15s
+      retries: 10
+      start_period: 20s
     labels:
       com.pipeline.component: "zookeeper"
       com.pipeline.tier: "data"


### PR DESCRIPTION
## Summary
- Replace `echo ruok | nc localhost 2181` zookeeper healthcheck with `cub zk-ready` (Confluent-native, available in the image)
- Increase healthcheck retries (5 → 10) and start_period (15s → 20s) for slower CI runners
- Increase integration test sleep (45s → 60s)

## Problem
The `nc` (netcat) command is not available in the `confluentinc/cp-zookeeper:7.5.0` Docker image on GitHub Actions runners, causing the zookeeper container to be marked unhealthy. Since kafka depends on `zookeeper: service_healthy`, the entire integration test fails with `dependency failed to start: container zookeeper is unhealthy`.

## Test plan
- [x] `docker compose config --quiet` passes
- [x] 49/49 pytest tests pass locally
- [ ] CI integration test passes with new healthcheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)